### PR TITLE
-#4664 Se arregló el problema de los filtros en uso que no mostraban …

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/js/filter_control.js
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/js/filter_control.js
@@ -33,7 +33,10 @@ function create_filter_badgets (){
 		 closeButton.className="glyphicon glyphicon-remove";
 		 filter_div.append(closeButton);
 		 text=document.createElement("p");
-		 text.innerHTML=filter.type+": "+filter.query;
+		 if (filter.relational_operator.startsWith("not"))
+			 text.innerHTML=filter.type+" &#8800 "+filter.query;
+		 else
+			 text.innerHTML=filter.type+": "+filter.query;
 		 filter_div.append(text);
 		 filter_div.className="btn btn-info";
 		 filter_div.setAttribute("index", index);

--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/discovery.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/discovery.xsl
@@ -236,8 +236,17 @@
 	               window.DSpace.discovery.filters.push({
 	               type: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript($type)"/><xsl:text>',
 	               relational_operator: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(dri:cell/dri:field[starts-with(@n, 'filter_relational_operator')]/dri:value/@option)"/><xsl:text>',
-	               query: '</xsl:text><xsl:value-of select="stringescapeutils:escapeEcmaScript(xmlui:replaceAll($value,'(\([a-zA-Z]*.*[1-9]+\))',' '))"/><xsl:text>',
-	            });
+	               query: '</xsl:text>
+	                       <xsl:choose>
+	                         <xsl:when test="$value">
+	                           <xsl:value-of select="stringescapeutils:escapeEcmaScript(xmlui:replaceAll($value,'(\([a-zA-Z]*.*[1-9]+\))',' '))"/>
+	                         </xsl:when>
+	                         <xsl:otherwise>
+	                           <xsl:value-of select="$query"/>
+	                         </xsl:otherwise>
+	                       </xsl:choose>
+	                       <xsl:text>',
+	               });
 	         </xsl:text>
 	         </xsl:for-each>
             


### PR DESCRIPTION
…bien el label cuando se usaban los filtros avanzados

Ademas se agregó que cuando se filtra por 'no es', 'no contiene' o 'no es id', se muestre el simbolo NOT EQUAL TO (!=)