### PR TITLE
-#4658 Ahora no hay problemas cuando se genera la vista reducida del …

### DIFF
--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -102,8 +102,7 @@
 					</xsl:call-template>
 			</xsl:when>
 			<xsl:when test="($disableOutputEscaping='True') and ($reduced='True')">
-				<xsl:value-of select="substring(text(),1,200)" disable-output-escaping="yes"/>
-				<xsl:value-of select="concat(substring-before(substring(text(),200,300),'.'), '.')" disable-output-escaping="yes"/>
+				<xsl:value-of select="xmlui:getShortAbstract(text())" disable-output-escaping="yes"/>
 			</xsl:when>
 			<xsl:when test="$disableOutputEscaping='True'">
 				<xsl:value-of select="text()" disable-output-escaping="yes"/>


### PR DESCRIPTION
…resumen de un item

Se agregaron 2 métodos en XSLTHelper que generan la vista reducida de un resumen de forma correcta, teniendo en cuenta la longitud del texto y si quedan o no tags sin cerrar al recortar el resumen