### PR TITLE
-#4702 Se cambio la forma en la que se generan los links al cambio de…

### DIFF
--- a/dspace/modules/xmlui/src/main/java/ar/edu/unlp/sedici/dspace/xmlui/util/XSLTHelper.java
+++ b/dspace/modules/xmlui/src/main/java/ar/edu/unlp/sedici/dspace/xmlui/util/XSLTHelper.java
@@ -134,6 +134,15 @@ public class XSLTHelper {
 
 	}
 	
+    /*
+     * Retorna un conjunto de property values desde el dspace.cfg dada una property key.
+     */
+    public static String getPropertyValuesAsString(String property){
+
+        String[] properties= DSpaceServicesFactory.getInstance().getConfigurationService().getArrayProperty(property);
+        return String.join(",",properties);
+    }
+
 	/*
 	 * Retorna un conjunto de property keys desde el dspace.cfg cuyo prefijo coincida.
 	 */


### PR DESCRIPTION
… idioma

Ahora en el xsl los links al cambio de idioma se generan directamente a partir de la url actual utilizando el atributo href de un tag <a>,
y no a partir de un metadato como se genraba antes con el template 'build-anchor'.
Simplemente se concatena al final de la url el atributo 'locale-atribute=<idioma que se seteó>'