### PR TITLE
-#4705 Se cambió la configuración del portugués en dspace.cfg

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1253,7 +1253,7 @@ default.locale = es
 # A comma-separated list of Locales. All types of Locales country, country_language, country_language_variant
 # Note that the appropriate file are present, especially that all the Messages_x.properties are there
 # may be used, e. g: 
-webui.supported.locales = es, en, pt
+webui.supported.locales = es, en, pt_BR
 
 #### Submission License substitution variables ####
 # it is possible include contextual information in the submission license using substitution variables


### PR DESCRIPTION
Antes la clave para el portugués estaba como 'pt', lo que era incorrecto; se cambió por 'pt_BR'