### PR TITLE
-#4763 Los autores e instituciones ahora se indexan sin sus siglas ni filiaciones

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Author_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Author_CICBA_Authority.java
@@ -51,23 +51,14 @@ public class Author_CICBA_Authority extends AdvancedSPARQLAuthorityProvider {
 		ParameterizedSparqlString pqs = new ParameterizedSparqlString();
 
 		pqs.setNsPrefix("foaf", NS_FOAF);
-		pqs.setNsPrefix("dc", NS_DC);
-		pqs.setNsPrefix("cerif", NS_CERIF);
 		pqs.setNsPrefix("rdf", NS_RDF);
-		pqs.setNsPrefix("sioc", NS_SIOC);
 
-		pqs.setCommandText("CONSTRUCT { ?person a foaf:Person. ?person foaf:givenName ?name . ?person foaf:mbox ?mail . ?person foaf:familyName ?surname. ?person cerif:linksToOrganisationUnit ?link . ?link cerif:startDate ?inicio. ?link cerif:endDate ?fin . ?link foaf:Organization ?org . ?org dc:title ?affiliation. ?org sioc:id ?id. }\n");
+		pqs.setCommandText("CONSTRUCT { ?person a foaf:Person. ?person foaf:givenName ?name . ?person foaf:familyName ?surname. }\n");
 		pqs.append("WHERE {\n");
 		pqs.append("?person a foaf:Person ; foaf:givenName ?name ; foaf:familyName ?surname .\n");
-		pqs.append("	OPTIONAL {\n");
-		pqs.append("	?person foaf:mbox ?mail . \n");
-		pqs.append("	} . \n");
-		pqs.append("	OPTIONAL {\n");
-		pqs.append("	?person cerif:linksToOrganisationUnit ?link . ?link cerif:startDate ?inicio; cerif:endDate ?fin; foaf:Organization ?org . ?org dc:title ?affiliation; sioc:id ?id\n");
-		pqs.append("	}\n");
 		pqs.append("FILTER(REGEX(?person, ?key, \"i\"))\n");
 		pqs.append("}\n");
-		pqs.append("ORDER BY ?surname ?link\n");
+		pqs.append("ORDER BY ?surname \n");
 
 		pqs.setLiteral("key", key);
 		return pqs;

--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Institution_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Institution_CICBA_Authority.java
@@ -52,12 +52,12 @@ public class Institution_CICBA_Authority extends SimpleSPARQLAuthorityProvider {
 	protected Choice extractChoice(QuerySolution solution) {
 		String key = solution.getResource("concept").getURI();
 		String label = solution.getLiteral("label").getString();
-		
+		String value = label;
 		if (solution.contains("initials") && !"".equals(solution.getLiteral("initials").getString())) {
 			String initials = solution.getLiteral("initials").getString();
 			label = label + " (" + initials + ")";
 		}
 		
-		return new Choice(key, label, label);
+		return new Choice(key, value, label);
 	}
 }

--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Institution_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Institution_CICBA_Authority.java
@@ -14,12 +14,10 @@ public class Institution_CICBA_Authority extends SimpleSPARQLAuthorityProvider {
 
 		pqs.setNsPrefix("foaf", NS_FOAF);
 		pqs.setNsPrefix("dc", NS_DC);
-		pqs.setNsPrefix("sioc", NS_SIOC);
 
-		pqs.setCommandText("SELECT ?concept ?label ?initials\n");
+		pqs.setCommandText("SELECT ?concept ?label \n");
 		pqs.append("WHERE {\n");
 		pqs.append("?concept a foaf:Organization ; dc:title ?label .\n");
-		pqs.append("OPTIONAL { ?concept sioc:id ?initials} \n");
 		pqs.append("FILTER(REGEX(?concept, ?key, \"i\"))\n");
 		pqs.append("}\n");
 


### PR DESCRIPTION
Se modificaron los mensajes getSparqlSearchByIdQuery en los authorities providers para institucion y autor, para que cuando se indexen contenidos no se agreguen sus siglas y filiaciones