### PR TITLE
-4834 Se agregó el metadato cic.institucionOrigen

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1533,6 +1533,12 @@ choices.presentation.cic.lugarDesarrollo = suggest
 authority.controlled.cic.lugarDesarrollo = true
 choices.closed.cic.lugarDesarrollo = false
 choices.minLength.cic.lugarDesarrollo = 3
+#--cic.institucionOrigen---
+choices.plugin.cic.institucionOrigen = Institution_CICBA_Authority
+choices.presentation.cic.institucionOrigen = suggest
+authority.controlled.cic.institucionOrigen = true
+choices.closed.cic.institucionOrigen = false
+choices.minLength.cic.institucionOrigen = 3
 #---dcterms.isPartOf.series---
 choices.plugin.dcterms.isPartOf.series = Journal_CICBA_Authority
 choices.presentation.dcterms.isPartOf.series = suggest

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -198,6 +198,16 @@
          <hint>Institución, departamento y/o unidad en la cual se desarrolló el trabajo. En el caso de informes de investigación, corresponde al punto 4.</hint>
          <required>Debe indicar el lugar o lugares donde se desarrolló el trabajo.</required>
        </field>
+
+       <field>
+         <dc-schema>cic</dc-schema>
+         <dc-element>institucionOrigen</dc-element>
+         <repeatable>true</repeatable>
+         <label>Centro CIC</label>
+         <input-type>onebox</input-type>
+         <hint>Centro CIC al que pertenece la obra</hint>
+         <required>Debe indicar el centro CIC al que pertenece la obra.</required>
+       </field>
      
      	<field>
          <dc-schema>dcterms</dc-schema>
@@ -554,12 +564,12 @@
      
      	<field>
          <dc-schema>cic</dc-schema>
-         <dc-element>lugarDesarrollo</dc-element>
+         <dc-element>institucionOrigen</dc-element>
          <repeatable>true</repeatable>
-         <label>Lugar de desarrollo</label>
+         <label>Centro CIC</label>
          <input-type>onebox</input-type>
-         <hint>Institución, departamento y/o unidad en la cual se desarrolló el trabajo. En el caso de informes de investigación, corresponde al punto 4.</hint>
-         <required>Debe indicar el lugar o lugares donde se desarrolló el trabajo.</required>
+         <hint>Centro CIC al que pertenece la obra</hint>
+         <required>Debe indicar el centro CIC al que pertenece la obra.</required>
        </field>
      
      	<field>

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -208,4 +208,10 @@
 		<scope_note>Nombre del programa de radio</scope_note>
 	</dc-type>
 
+	<dc-type>
+		<schema>cic</schema>
+		<element>institucionOrigen</element>
+		<scope_note>Centro CIC al que pertenece la obra</scope_note>
+	</dc-type>
+
 </dspace-dc-types>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2340,6 +2340,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-cic_isPeerReviewed">Peer reviewed</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-cic_isFulltext">Fulltext</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-cic_lugarDesarrollo">Origin info</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-cic_institucionOrigen">CIC Center</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dc_date_available">Date of availability</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dc_date_accessioned">Date of accession</message>
@@ -2525,6 +2526,8 @@
 <message key="xmlui.ChoiceLookupTransformer.field.cic_thesis_grantor.title">Look up Grantor Institution</message>
 <message key="xmlui.ChoiceLookupTransformer.field.cic_lugarDesarrollo.help">Development place</message>
 <message key="xmlui.ChoiceLookupTransformer.field.cic_lugarDesarrollo.title">Look up Development Place</message>
+<message key="xmlui.ChoiceLookupTransformer.field.cic_institucionOrigen.help">CIC Center</message>
+<message key="xmlui.ChoiceLookupTransformer.field.cic_institucionOrigen.title">Look up CIC Center</message>
 <message key="xmlui.ChoiceLookupTransformer.field.dcterms_isPartOf_series.help">Journal or Event</message>
 <message key="xmlui.ChoiceLookupTransformer.field.dcterms_isPartOf_series.title">Look up Journal or Event</message>
 <message key="xmlui.ChoiceLookupTransformer.field.dcterms_language.help">Language</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -2235,6 +2235,8 @@ Puede reemplazar la plantilla que gestiona el caso general dri2xhtml para mejora
 <message key="xmlui.dri2xhtml.METS-1.0.item-cic_isPeerReviewed">Revisado por pares</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-cic_isFulltext">Texto completo</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-cic_lugarDesarrollo">Lugar de desarrollo</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-cic_institucionOrigen">Centro CIC</message>
+
 
 <message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Archivos</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Archivo</message>
@@ -2411,6 +2413,8 @@ Cuando se usa QDC para los elementos de DSpace se recomienda el uso de crosswalk
 <message key="xmlui.ChoiceLookupTransformer.field.cic_thesis_grantor.title">Buscar Institutición otorgante</message>
 <message key="xmlui.ChoiceLookupTransformer.field.cic_lugarDesarrollo.help">Lugar de Desarrollo</message>
 <message key="xmlui.ChoiceLookupTransformer.field.cic_lugarDesarrollo.title">Buscar Lugar de Desarrollo</message>
+<message key="xmlui.ChoiceLookupTransformer.field.cic_institucionOrigen.help">Centro CIC</message>
+<message key="xmlui.ChoiceLookupTransformer.field.cic_institucionOrigen.title">Buscar Centro CIC</message>
 <message key="xmlui.ChoiceLookupTransformer.field.dcterms_isPartOf_series.help">Revista o Evento</message>
 <message key="xmlui.ChoiceLookupTransformer.field.dcterms_isPartOf_series.title">Buscar Revista o Evento</message>
 <message key="xmlui.ChoiceLookupTransformer.field.dcterms_language.help">Idioma</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
@@ -2729,6 +2729,7 @@
     <message key="xmlui.dri2xhtml.METS-1.0.item-cic_isPeerReviewed">Revisado por pares</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-cic_isFulltext">Texto completo</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-cic_lugarDesarrollo">Lugar de desenvolvimento</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-cic_institucionOrigen">Centro CIC</message>
     <message key="xmlui.ChoiceLookupTransformer.field.dcterms_subject_materia.help">Nome do Assunto</message>
     <message key="xmlui.ChoiceLookupTransformer.field.dcterms_subject_materia.title">Procurar Assunto</message>
     <message key="xmlui.ChoiceLookupTransformer.field.dcterms_subject.help">Palavra Chave</message>
@@ -2747,6 +2748,8 @@
     <message key="xmlui.ChoiceLookupTransformer.field.cic_thesis_grantor.title">Procurar Instituição Outorgante</message>
     <message key="xmlui.ChoiceLookupTransformer.field.cic_lugarDesarrollo.help">Lugar de Desenvolvimento</message>
     <message key="xmlui.ChoiceLookupTransformer.field.cic_lugarDesarrollo.title">Procurar lugar de Desenvolvimento</message>
+    <message key="xmlui.ChoiceLookupTransformer.field.cic_institucionOrigen.help">Centro CIC</message>
+    <message key="xmlui.ChoiceLookupTransformer.field.cic_institucionOrigen.title">Procurar Centro CIC</message>
     <message key="xmlui.ChoiceLookupTransformer.field.dcterms_isPartOf_series.help">Revista ou Evento</message>
     <message key="xmlui.ChoiceLookupTransformer.field.dcterms_isPartOf_series.title">Procurar Revista ou Evento</message>
     <message key="xmlui.ChoiceLookupTransformer.field.dcterms_language.help">Idioma</message>

--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -641,6 +641,10 @@
 						<xsl:with-param name="container" select="'li'" />
 					</xsl:call-template>
 					<xsl:call-template name="render-metadata">
+					    <xsl:with-param name="field" select="cic.institucionOrigen"/>
+					    <xsl:with-param name="container"    select="'li'"/>
+					</xsl:call-template>
+					<xsl:call-template name="render-metadata">
 						<xsl:with-param name="field" select="'dcterms.publisher'" />
 						<xsl:with-param name="container" select="'li'" />
 					</xsl:call-template>

--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -641,7 +641,7 @@
 						<xsl:with-param name="container" select="'li'" />
 					</xsl:call-template>
 					<xsl:call-template name="render-metadata">
-					    <xsl:with-param name="field" select="cic.institucionOrigen"/>
+					    <xsl:with-param name="field" select="'cic.institucionOrigen'"/>
 					    <xsl:with-param name="container"    select="'li'"/>
 					</xsl:call-template>
 					<xsl:call-template name="render-metadata">


### PR DESCRIPTION
Se siguieron los pasos indicados en la wiki, se agregó en input-forms el campo Centro CIC bajo el metadato nuevo y se eliminó del formulario de autoarchivo el metadato cic.lugarDesarrollo
EL nuevo metadato es authority controlled pero da la posibilidad de que tome el valor de cualquier institucion, falta agregar una clase que restrinja los valores solo a las instituciones que son centros cic, tal como se aclara en los comentarios de este ticket