### PR TITLE
Mejoras a la página de add/edit bitstreams

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowItemUtils.java
@@ -15,14 +15,12 @@ import java.util.*;
 
 import org.apache.cocoon.environment.Request;
 import org.apache.cocoon.servlet.multipart.Part;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateUtils;
 import org.dspace.app.util.Util;
 import org.dspace.app.xmlui.utils.UIException;
 import org.dspace.app.xmlui.wing.Message;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;
-import org.dspace.authorize.ResourcePolicyServiceImpl;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.authorize.service.ResourcePolicyService;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/AddBitstreamForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/AddBitstreamForm.java
@@ -19,6 +19,7 @@ import org.dspace.app.xmlui.wing.Message;
 import org.dspace.app.xmlui.wing.WingException;
 import org.dspace.app.xmlui.wing.element.Body;
 import org.dspace.app.xmlui.wing.element.Button;
+import org.dspace.app.xmlui.wing.element.CheckBox;
 import org.dspace.app.xmlui.wing.element.Division;
 import org.dspace.app.xmlui.wing.element.File;
 import org.dspace.app.xmlui.wing.element.Item;
@@ -61,7 +62,11 @@ public class AddBitstreamForm extends AbstractDSpaceTransformer
 	private static final Message T_description_label = message("xmlui.administrative.item.AddBitstreamForm.description_label");
 	private static final Message T_description_help = message("xmlui.administrative.item.AddBitstreamForm.description_help");
 	private static final Message T_submit_upload = message("xmlui.administrative.item.AddBitstreamForm.submit_upload");
-
+	private static final Message T_open_access_label = message("xmlui.administrative.item.EditBitstreamForm.open_access_label");
+	private static final Message T_open_access_help = message("xmlui.administrative.item.EditBitstreamForm.open_access_help");
+	private static final Message T_open_access_checkBox_help = message("xmlui.administrative.item.EditBitstreamForm.open_access_checkBox_help");
+	private static final Message T_open_access_title = message("xmlui.administrative.item.EditBitstreamForm.open_access_title");
+	private static final Message T_open_access_embargo_disabled = message("xmlui.administrative.item.EditBitstreamForm.open_access_embargo_disabled");
 	private static final Message T_no_bundles = message("xmlui.administrative.item.AddBitstreamForm.no_bundles");
 
 	
@@ -145,15 +150,24 @@ public class AddBitstreamForm extends AbstractDSpaceTransformer
                 upload.addItem().addContent(T_no_bundles);
             }
 
+
+            //Open access fields
+            List openAccessSection= upload.addList("openAccessSection",List.TYPE_FORM);
+            openAccessSection.setHead(T_open_access_title);
+            //Private bitstream CheckBox
+            CheckBox privateBitstream = openAccessSection.addItem().addCheckBox("publicBitstream");
+            privateBitstream.setLabel(T_open_access_label);
+            privateBitstream.setHelp(T_open_access_help);
+            privateBitstream.addOption(true,"public-bitstream").addContent(T_open_access_checkBox_help);
+            openAccessSection.addItem("embargo-disabled",null).addContent(T_open_access_embargo_disabled);
             // EMBARGO FIELD
             // if AdvancedAccessPolicy=false: add Embargo Fields.
             if(!isAdvancedFormEnabled){
                 AccessStepUtil asu = new AccessStepUtil(context);
                 // if the item is embargoed default value will be displayed.
-                asu.addEmbargoDateSimpleForm(item, upload, -1);
-                asu.addReason(null, upload, -1);
+                asu.addEmbargoDateSimpleForm(item, openAccessSection, -1);
+                asu.addReason(null, openAccessSection, -1);
             }
-
 
 
             // ITEM: actions

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
@@ -11,9 +11,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import org.apache.commons.jxpath.ri.compiler.Constant;
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
 import org.dspace.app.xmlui.aspect.submission.submit.AccessStepUtil;
 import org.dspace.app.xmlui.cocoon.AbstractDSpaceTransformer;
 import org.dspace.app.xmlui.utils.UIException;
@@ -33,7 +31,6 @@ import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
-import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
@@ -89,7 +89,7 @@ public class EditBitstreamForm extends AbstractDSpaceTransformer
 	protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
 	protected BitstreamFormatService bitstreamFormatService = ContentServiceFactory.getInstance().getBitstreamFormatService();
 
-	private static final String[] DEFAULT_BUNDLE_LIST = new String[]{"ORIGINAL", "METADATA", "THUMBNAIL", "LICENSE", "CC-LICENSE"};
+	private static final String[] DEFAULT_BUNDLE_LIST = new String[]{"ORIGINAL"};
 	private static final Message T_bundle_label = message("xmlui.administrative.item.AddBitstreamForm.bundle_label");
 	protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
 
@@ -151,7 +151,6 @@ public class EditBitstreamForm extends AbstractDSpaceTransformer
         edit.addLabel(T_file_label);
         edit.addItem(null,"break-all").addXref(fileUrl, fileName);
 
-        int bundleCount = 0; // record how many bundles we are able to upload too.
         Select select = edit.addItem().addSelect("bundle");
         select.setLabel(T_bundle_label);
 
@@ -164,14 +163,10 @@ public class EditBitstreamForm extends AbstractDSpaceTransformer
         }
         for (String part : bundlesNames)
         {
-            if (part.equals(bitstream.getBundles().get(0).getName())){
+            if (part.equals(bitstream.getBundles().get(0).getName()))
                 select.addOption(true,part, message("xmlui.administrative.item.AddBitstreamForm.bundle." + part));
-                bundleCount++;
-            }
-            else if (addBundleOption(item, select, part.trim()))
-            {
-                bundleCount++;
-            }
+            else
+                addBundleOption(item, select, part.trim());
         }
 
         Text bitstreamName = edit.addItem().addText("bitstreamName");

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditBitstreamForm.java
@@ -56,6 +56,7 @@ public class EditBitstreamForm extends AbstractDSpaceTransformer
 	private static final Message T_dspace_home = message("xmlui.general.dspace_home");
 	private static final Message T_submit_save = message("xmlui.general.save");
 	private static final Message T_submit_cancel = message("xmlui.general.cancel");
+	private static final Message T_submit_back = message("xmlui.general.return");
 	private static final Message T_item_trail = message("xmlui.administrative.item.general.item_trail");
 	
 	private static final Message T_title = message("xmlui.administrative.item.EditBitstreamForm.title");
@@ -274,12 +275,14 @@ public class EditBitstreamForm extends AbstractDSpaceTransformer
 
 		}
 
+		// ITEM: form actions
+		org.dspace.app.xmlui.wing.element.Item actions = edit.addItem();
 		if (isEditableBitstream) {
-		    // ITEM: form actions
-		    org.dspace.app.xmlui.wing.element.Item actions = edit.addItem();
 		    actions.addButton("submit_save").setValue(T_submit_save);
 		    actions.addButton("submit_cancel").setValue(T_submit_cancel);
 		}
+		else
+		    actions.addButton("submit_cancel").setValue(T_submit_back);
 
 		div.addHidden("administrative-continue").setValue(knot.getId()); 
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2119,6 +2119,7 @@ mirage2.item-view.bitstream.href.label.2 = title
 # have the appropriate privileges (add & write) on the bundle then that bundle will
 # not be shown to the user as an option.
 #xmlui.bundle.upload = ORIGINAL, METADATA, THUMBNAIL, LICENSE, CC-LICENSE
+#xmlui.bundle.editable = ORIGINAL
 
 # On the community-list page should all the metadata about a community/collection
 # be available to the theme. This parameter defaults to true, but if you are

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -1627,6 +1627,11 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">The application you used to create the file, and the version number (for example, "<i>ACMESoft SuperApp version 1.5</i>").</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Filename:</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Change the filename for this bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_label">Open access to bitstream</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_help">By allowing open access to a bitstream, it will be visible to the entire community. Otherwise, only administrators and the owner of the item will have access to it.</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_checkBox_help">Allow open access to the bitstream</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_title">Open access settings</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_embargo_disabled">Can not apply an embargo to a private bitstream (without open access enabled)</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item Bitstreams</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -1561,6 +1561,11 @@
 <message key="xmlui.administrative.item.EditBitstreamForm.user_help">El nombre y versión de la aplicación que utilizó para crear el fichero (por ejemplo, "<i>ACMESoft SuperApp versión 1.5</i>").</message>
 <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nombre del fichero:</message>
 <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Renombrar este fichero. Nótese que se cambiará la URL mostrada, pero los enlaces antiguos se seguirán resolviendo mientras no cambie el ID.</message>
+<message key="xmlui.administrative.item.EditBitstreamForm.open_access_label">Acceso abierto al bitstream</message>
+<message key="xmlui.administrative.item.EditBitstreamForm.open_access_help">Al permitir el acceso abierto a un bitstream, este será visible para toda la comunidad. En caso contrario, solo será accesible para los administradores y el dueño del item.</message>
+<message key="xmlui.administrative.item.EditBitstreamForm.open_access_checkBox_help">Otorgar acceso abierto al bitstream</message>
+<message key="xmlui.administrative.item.EditBitstreamForm.open_access_title">Configuración de acceso abierto</message>
+<message key="xmlui.administrative.item.EditBitstreamForm.open_access_embargo_disabled">No se puede aplicar un embargo a un bitstream privado (sin acceso abierto habilitado)</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 <message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Archivos del ítem</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
@@ -1416,7 +1416,11 @@
     <message key="xmlui.administrative.item.EditBitstreamForm.user_help">O aplicativo usado para criar o arquivo, e o número da versão (por exemplo, "<i>ACMESoft SuperApp version 1.5</i>").</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nome do arquivo</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Renomeie o arquivo para o bitstream. Note que isto irá mudar a exibição da URL bistream , mas links antigos ainda serão usados enquanto a sequencia ID não muda.</message>
-
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_label">Acesso aberto ao bitstream</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_help">Ao permitir acesso aberto a um bitstream, ele ficará visível para toda a comunidade. Caso contrário, somente os administradores e o proprietário do item terão acesso a ele.</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_checkBox_help">Permitir acesso aberto ao bitstream</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_title">Configuração de acesso aberto</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.open_access_embargo_disabled">Nenhum embargo pode ser aplicado a um bitstream privado (com acesso aberto desativado)</message>
     <!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
     <message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item Bitstreams</message>
     <message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Item bitstreams</message>

--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/js/embargo_enable_disable.js
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/js/embargo_enable_disable.js
@@ -1,0 +1,28 @@
+function embargo_toggle (){
+	checkBox=document.getElementsByName('publicBitstream')[0];
+	embargoDisabled=document.querySelector("[id$='embargo-disabled']");
+	if (!checkBox.checked){
+        document.getElementsByName("embargo_until_date")[0].disabled = true;
+    	document.getElementsByName("reason")[0].disabled = true;
+    	embargoDisabled.style.display="block";
+    	embargoDisabled.style.color="red";
+    	embargoDisabled.style.marginBottom="0px";
+    }
+	else{
+		embargoDisabled.style.display="none";
+	}
+	checkBox.onclick= function(e){
+    	embargoDisabled=document.querySelector("[id$='embargo-disabled']");
+		if (checkBox.checked){
+	        document.getElementsByName("embargo_until_date")[0].disabled = false;
+	        document.getElementsByName("reason")[0].disabled = false;
+	        embargoDisabled.style.display="none";
+	    } else {
+	    	document.getElementsByName("embargo_until_date")[0].disabled = true;
+	    	document.getElementsByName("reason")[0].disabled = true;
+	    	embargoDisabled.style.display="block";
+	    	embargoDisabled.style.color="red";
+	    	embargoDisabled.style.marginBottom="0px";
+	    }
+	}
+}

--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/core/page-structure.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/core/page-structure.xsl
@@ -657,6 +657,19 @@
             </script>
          </xsl:if>
 
+         <xsl:if test="(/dri:document/dri:body/dri:div[@id='aspect.administrative.item.EditBitstreamForm.div.edit-bitstream']) or (/dri:document/dri:body/dri:div[@id='aspect.administrative.item.AddBitstreamForm.div.add-bitstream'])">
+            <script type="text/javascript">
+                <xsl:attribute name="src">
+                    <xsl:call-template name="print-theme-path">
+                        <xsl:with-param name="path">js/embargo_enable_disable.js</xsl:with-param>
+                    </xsl:call-template>
+                </xsl:attribute>&#160;
+            </script>
+            <script type="text/javascript">
+                embargo_toggle();
+            </script>
+         </xsl:if>
+
 	</xsl:template>
 
 


### PR DESCRIPTION
-#4842 Ahora desde la página de add/edit bitstreams se puede: seleccionar el bundle tanto al crear como al editar, editar un embargo y poner un item como privado (sin RP para anonymous)

Se reformuló la vista de add/edit bitstream. Se agregó una sección de configuracion de acceso abierto donde se puede poner como privado un bitstream (sin acceso para anonymous) y modificar lo relacionado con el embargo.
Se decidió que no se puede aplicar un embargo a un bitstream privado.

También se agegó que solo sean editables los bitstreams pertenecientes al bundle ORIGINAL (en realidad los pertenecientes a una lista de bundles editables en la que actualmente solo se encuentra ORIGINAL).

Si se quiere editar un bitstream que no pertenece a un bundle de esa lista, aparecerán todos los inputs del formulario de edición deshabilitados y no se mostrará el botón "guardar" (se mostrará el formulario como de solo lectura).

