### PR TITLE
-#4597 Ahora en la exportación a CSV de una búsqueda en Discovery, lo…

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/CSVExportDiscoveryNavigation.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/discovery/CSVExportDiscoveryNavigation.java
@@ -125,7 +125,7 @@ public class CSVExportDiscoveryNavigation  extends AbstractDSpaceTransformer imp
         {
         	for(int i = 0; i < fqs.length; i++) {
             	if(i < fqs.length - 1)
-            		filters += fqs[i] + ",";
+            		filters += fqs[i] + ";";
             	else
             		filters += fqs[i];
             }

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/SearchMetadataExportReader.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/cocoon/SearchMetadataExportReader.java
@@ -234,7 +234,7 @@ public class SearchMetadataExportReader extends AbstractReader implements Recycl
         // set the object model on the simple search object
         simpleSearch.objectModel = objectModel;
         
-        String[] fqs = filters != null ? filters.split(",") : new String[0];
+        String[] fqs = filters != null ? filters.split(";") : new String[0];
         
         // prepare query from SimpleSearch object
         qArgs = simpleSearch.prepareQuery(scope, query, fqs);


### PR DESCRIPTION
…s filtros de la búsqueda, que luego se utilizan en la consulta a solr, se separan por ";" en vez de ","

Ocurria un problema cuando se separaban por "," y se utilizaba algún filtro que contenía una "," en su valor.