### PR TITLE
-#4911 Se hizo un fix de los cambios hechos en #4842

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -81,6 +81,11 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 			return choices[0].label;
 	}
 
+    /**
+     * Este metodos construye la query sparql que posteriormente será ejecutada en drupal
+     *
+     *  @param idSearch Determina el tipo de query, si se hará la busqueda por id (key) de autoridad o por texto
+     */
 	protected abstract ParameterizedSparqlString getSparqlSearch(String field, String filter, String locale,boolean idSearch);
 
 	protected abstract Choice[] extractChoicesfromQuery(QueryEngineHTTP httpQuery);

--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/General_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/General_CICBA_Authority.java
@@ -40,7 +40,7 @@ public class General_CICBA_Authority extends SPARQLAuthorityProvider {
 		pqs.setNsPrefix("cic", NS_CIC);
 		pqs.setNsPrefix("skos", NS_SKOS);
 
-		pqs.setCommandText("SELECT "+ this.getSelectQueryFields() + "\n");
+		pqs.setCommandText("SELECT "+ this.getSelectQueryFields(idSearch) + "\n");
 		pqs.append("WHERE {\n");
 		pqs.append("?concept a "+ typeProperty + " .\n");
 		pqs.append("?concept "+ labelProperty +" ?label .\n");
@@ -76,7 +76,7 @@ public class General_CICBA_Authority extends SPARQLAuthorityProvider {
 		return pqs;
 	}
 
-	protected String getSelectQueryFields(){
+	protected String getSelectQueryFields(boolean idSearch){
 		return "?concept ?label";
 	}
 

--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Institution_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Institution_CICBA_Authority.java
@@ -7,8 +7,12 @@ import com.hp.hpl.jena.query.QuerySolution;
 public class Institution_CICBA_Authority extends General_CICBA_Authority {
 
 	@Override
-	protected String getSelectQueryFields() {
-		return super.getSelectQueryFields() +" ?initials";
+	protected String getSelectQueryFields(boolean idSearch) {
+		String selectFields= super.getSelectQueryFields(idSearch);
+		//Si la query se hace por text hay que agregar la variable initials que retorna las siglas de la institucion
+		if (!idSearch)
+			selectFields +=" ?initials";
+		return selectFields;
 	}
 
 	@Override


### PR DESCRIPTION
Se había introducido un error en #4862, cuando se creaba la query de busqueda por id en la clase Institution_CICBA_AUthority se agregaba como variable en el select de sparql "?initials", que luego en el resto de la query no se usaba y eso generaba un error al ejecutar la consulta.
Se cambió eso y ahora cuando se realiza una búsqueda sparql por id de alguna institución ya no se utiliza ?initials en el select de la query