### PR TITLE
 "#4884" Escapo tildes en indexación y consulta de browse de autores

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseEngine.java
@@ -7,7 +7,6 @@
  */
 package org.dspace.browse;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -409,7 +408,7 @@ public class BrowseEngine
             // get the table name that we are going to be getting our data from
             // this is the distinct table constrained to either community or collection
             dao.setTable(browseIndex.getDistinctTableName());
-            dao.setStartsWith(StringUtils.lowerCase(scope.getStartsWith()));
+            dao.setStartsWith(OrderFormat.makeSortString(scope.getStartsWith(), null,(browseIndex.getDataType())));
             // remind the DAO that this is a distinct value browse, so it knows what sort
             // of query to build
             dao.setDistinct(true);

--- a/dspace-api/src/main/java/org/dspace/text/filter/DecomposeDiactritics.java
+++ b/dspace-api/src/main/java/org/dspace/text/filter/DecomposeDiactritics.java
@@ -19,12 +19,12 @@ public class DecomposeDiactritics implements TextFilter
     @Override
     public String filter(String str)
     {
-        return Normalizer.normalize(str, Normalizer.NFD);
+        return Normalizer.normalize(str, Normalizer.NFD).replaceAll("[\\p{InCombiningDiacriticalMarks}]", "");
     }
 
     @Override
     public String filter(String str, String lang)
     {
-        return Normalizer.normalize(str, Normalizer.NFD);
+        return Normalizer.normalize(str, Normalizer.NFD).replaceAll("[\\p{InCombiningDiacriticalMarks}]", "");
     }
 }


### PR DESCRIPTION
Se quitaron los acentos al momento de armar el facet que se utilizará en el browse de autores y se filtraron los acentos del string ingresado en la búsqueda de la misma forma que cuando se indexa.
