### PR TITLE
-#3350 Se cambio la forma en que se cargan los pdfs en memoria a la h…

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -110,13 +110,13 @@ public class PDFFilter extends MediaFilter
                 if (source instanceof FileInputStream) {
 
                   long fileSize = ((FileInputStream) source).getChannel().size();
-                  long minSize  = ConfigurationManager.getLongProperty("pdffilter.memoryToTempFileLimitInMb", 5)*1024*1024;
-                  float xmxFactor = (float) ConfigurationManager.getIntProperty("pdffilter.maxSizeHeapPercentage",100)/100;
+                  long minSize  = ConfigurationManager.getLongProperty("pdffilter.memoryToTempFileLimitInMb", 5) * 1024 * 1024;
+                  float xmxFactor = (float) ConfigurationManager.getIntProperty("pdffilter.maxSizeHeapPercentage", 100) / 100;
 
-                  if (((FileInputStream) source).getChannel().size()<minSize) {
+                  if (((FileInputStream) source).getChannel().size() < minSize) {
                       pdfDoc = PDDocument.load(source);
                   }
-                  else if(fileSize < (long) (Runtime.getRuntime().maxMemory()*xmxFactor)){
+                  else if(fileSize < (long) (Runtime.getRuntime().maxMemory() * xmxFactor)){
                       pdfDoc = PDDocument.load(source,MemoryUsageSetting.setupTempFileOnly());
                   }
                   else {

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -120,7 +120,8 @@ public class PDFFilter extends MediaFilter
                       pdfDoc = PDDocument.load(source,MemoryUsageSetting.setupTempFileOnly());
                   }
                   else {
-                      log.warn("PDF too large!");
+                      log.warn("PDF too large! (Item handle " + currentItem.getHandle() + "). PDF Size (" + fileSize + " bytes) "
+                      		+ "is bigger than the max filesize allowed (" + (long) (Runtime.getRuntime().maxMemory() * xmxFactor) + " bytes)");
                       return null;
                   }
                   pts.writeText(pdfDoc, writer);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -390,12 +390,12 @@ filter.org.dspace.app.mediafilter.PDFBoxThumbnail.inputFormats = Adobe PDF
 # all your memory
 #pdffilter.largepdfs = true
 
-#It determine the maximum size of pdf that will be rendered entirely in main memory
-#pdfs bigger than this size will be loaded by using temp files
+#Maximum fliesize in megabyes for pdf files to be loaded entirely in memory.
+#Files bigger than this setting will be processed using temp files
 pdffilter.memoryToTempFileLimitInMb = 10
 
-#This set the ratio used to calculate the maximum pdf size allowed to render
-#pdfs bigger than Runtime.getRuntime().maxMemory()*pdffilter.maxSizeHeapPercentage wont be loaded
+#Max pdf filesize allowed to be processed, expresed in percentaje of the heap space (Runtime.getRuntime().maxMemory())
+#i.e setting 110 and an Runtime.getRuntime().maxMemory()=2048m will allow the processing of files smaller than 2253MB (%*maxMemory())
 #pdffilter.maxSizeHeapPercentage = 100
 
 # If true, PDFs which still result in an Out of Memory error from PDFBox

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -389,6 +389,15 @@ filter.org.dspace.app.mediafilter.PDFBoxThumbnail.inputFormats = Adobe PDF
 # is slower, but helps ensure that PDFBox software DSpace uses doesn't eat up
 # all your memory
 #pdffilter.largepdfs = true
+
+#It determine the maximum size of pdf that will be rendered entirely in main memory
+#pdfs bigger than this size will be loaded by using temp files
+pdffilter.memoryToTempFileLimitInMb = 10
+
+#This set the ratio used to calculate the maximum pdf size allowed to render
+#pdfs bigger than Runtime.getRuntime().maxMemory()*pdffilter.maxSizeHeapPercentage wont be loaded
+#pdffilter.maxSizeHeapPercentage = 100
+
 # If true, PDFs which still result in an Out of Memory error from PDFBox
 # are skipped over...these problematic PDFs will never be indexed until
 # memory usage can be decreased in the PDFBox software


### PR DESCRIPTION
…ora de ser procesados por el filter-media

Ahora si los pdfs tiene un tamaño menor a lo declarado en pdffilter.memoryToTempFileLimitInMb en dspace.cfg, entonces se procesan completamente en memoria principal, caso contrario se procesan usando archivos temporales
Y si tienen un tamaño mayor a lo declarado en pdffilter.maxSizeHeapPercentage*Runtime.getRuntime().maxMemory() entonces no se procesan ya que es muy probable que generen un OutOfMemory