### PR TITLE
-#4839 Ahora, en la pantalla de editar metadatos de un item, se puede…

### DIFF
--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemMetadataForm.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/item/EditItemMetadataForm.java
@@ -197,7 +197,7 @@ public class EditItemMetadataForm extends AbstractDSpaceTransformer {
                 addAuthority.setLabel(T_authority_label);
                 
 
-                addForm.addItem().addButton("submit_add").setValue(T_submit_add);
+                addForm.addItem().addButton("submit_update").setValue(T_submit_add);
 
                 
                 

--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -1617,15 +1617,15 @@ function doEditItemMetadata(itemID, templateCollectionID)
 			// go back to wherever we came from.
 			return null;
 		}
-		else if (cocoon.request.get("submit_add"))
-		{
-			// Add a new metadata entry
-			result = FlowItemUtils.processAddMetadata(getDSContext(),itemID,cocoon.request);
-		}
 		else if (cocoon.request.get("submit_update"))
 		{
 			// Update the item
 			result = FlowItemUtils.processEditItem(getDSContext(),itemID,cocoon.request);
+			//Check if the user wants to add new metadata as well
+			if (cocoon.request.get("value") && (cocoon.request.get("value") != "")){
+				  // Add a new metadata entry
+				  result = FlowItemUtils.processAddMetadata(getDSContext(),itemID,cocoon.request);
+			}
 		}
 	} while (true)
 }


### PR DESCRIPTION
… editar y agregar metadatos a la vez

Antes si se queria agregar y editar metadatos de un item habia que hacer primero una accion y luego la otra.
Se cambio eso para que cuando se haga alguna de los dos acciones se ejecuten ambas.