### PR TITLE
 -#4904 Se habilitó la cache para el arbol de comunidades y colecciones

### DIFF
--- a/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/administrative.js
@@ -2483,10 +2483,14 @@ function doEditCollection(collectionID,newCollectionP)
 
 	do {
 
-		if (cocoon.request.get("submit_return") || cocoon.request.get("submit_save"))
+		if (cocoon.request.get("submit_return"))
 		{
 			// go back to wherever we came from.
 			return null;
+		}
+		else if (cocoon.request.get("submit_save"))
+		{
+			doEditCollectionMetadata(collectionID,-1)
 		}
 		else if (cocoon.request.get("submit_metadata"))
 		{
@@ -2524,12 +2528,18 @@ function doEditCollection(collectionID,newCollectionP)
  */
 function doEditCollectionMetadata(collectionID)
 {
+	var clearcache;
+	if (cocoon.request.get("submit_save"))
+		clearcache = "?clearcache=true";
+	else
+		clearcache = "";
+
 	assertEditCollection(collectionID);
 
 	var result;
 
 	do {
-		sendPageAndWait("admin/collection/editMetadata",{"collectionID":collectionID},result);
+		sendPageAndWait("admin/collection/editMetadata"+clearcache,{"collectionID":collectionID},result);
 		assertEditCollection(collectionID);
 		result=null;
 
@@ -2633,13 +2643,20 @@ function setOriginalWorkflowRoles(collectionID, result) {
 }
 function doAssignCollectionRoles(collectionID)
 {
+
+	var clearcache;
+	if (cocoon.request.get("submit_save"))
+		clearcache = "?clearcache=true";
+	else
+		clearcache = "";
+
 	assertEditCollection(collectionID);
 
 	var result;
 	var workflow = null;
 
 	do {
-		sendPageAndWait("admin/collection/assignRoles",{"collectionID":collectionID},result);
+		sendPageAndWait("admin/collection/assignRoles"+clearcache,{"collectionID":collectionID},result);
 		assertEditCollection(collectionID);
 		result = null;
 
@@ -2911,7 +2928,7 @@ function doDeleteCollection(collectionID)
 		var result = FlowContainerUtils.processDeleteCollection(getDSContext(),collectionID);
 
 		if (result.getContinue()) {
-			cocoon.redirectTo(cocoon.request.getContextPath()+"/community-list",true);
+			cocoon.redirectTo(cocoon.request.getContextPath()+"/community-list?clearcache=true",true);
 			getDSContext().complete();
 			cocoon.exit();
 		}
@@ -3048,11 +3065,17 @@ function doEditCommunity(communityID)
  */
 function doEditCommunityMetadata(communityID)
 {
+	var clearcache;
+	if (cocoon.request.get("submit_save"))
+		clearcache = "?clearcache=true";
+	else
+		clearcache = "";
+
 	assertEditCommunity(communityID);
 	var result;
 
 	do {
-		sendPageAndWait("admin/community/editMetadata",{"communityID":communityID},result);
+		sendPageAndWait("admin/community/editMetadata"+clearcache,{"communityID":communityID},result);
 		assertEditCommunity(communityID);
 		result=null;
 
@@ -3088,7 +3111,7 @@ function doDeleteCommunity(communityID) {
 		var result = FlowContainerUtils.processDeleteCommunity(getDSContext(),communityID);
 
 		if (result.getContinue()) {
-			cocoon.redirectTo(cocoon.request.getContextPath()+"/community-list",true);
+			cocoon.redirectTo(cocoon.request.getContextPath()+"/community-list?clearcache=true",true);
 			getDSContext().complete();
 			cocoon.exit();
 		}

--- a/dspace-xmlui/src/main/resources/aspects/Administrative/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/Administrative/sitemap.xmap
@@ -108,6 +108,7 @@ to administer DSpace.
     		<map:action name="ControlPanelAction" src="org.dspace.app.xmlui.aspect.administrative.ControlPanelAction" />
     		<map:action name="CurrentActivityAction" src="org.dspace.app.xmlui.aspect.administrative.CurrentActivityAction" />
                 <map:action name="ClearCacheAction" src="org.apache.cocoon.acting.ClearCacheAction"/>        
+                <map:action name="ClearCacheByGroupAction" src="ar.unlp.sedici.cocoon.acting.ClearCacheByGroupAction"/>
     	</map:actions>		
 		
 		<map:selectors>
@@ -338,8 +339,12 @@ to administer DSpace.
 		        		<map:match pattern="admin/not-authorized">
 		        			<map:transform type="NotAuthorized"/>
 		        	</map:match>
-		        		
-		        		
+
+		                <!-- If the 'clearcache' request parameter is specified, first clear the cocoon cache -->
+		                <map:match type="request" pattern="clearcache">
+		                     <map:act type="ClearCacheByGroupAction"/>
+		                </map:match>
+
 		        	<!-- EPeople management pages -->
 		        		
 		        		

--- a/dspace-xmlui/src/main/resources/aspects/BrowseArtifacts/sitemap.xmap
+++ b/dspace-xmlui/src/main/resources/aspects/BrowseArtifacts/sitemap.xmap
@@ -32,6 +32,11 @@ collections / items / and bitstreams.
                 <map:matcher name="HandleAuthorizedMatcher" src="org.dspace.app.xmlui.aspect.general.HandleAuthorizedMatcher"/>
                 <map:matcher name="ContainerHomePageSelector" src="org.dspace.app.xmlui.aspect.viewArtifacts.ContainerHomePageMatcher"/>
         </map:matchers>
+
+        <map:actions>
+                <map:action name="ClearCacheByGroupAction" src="ar.unlp.sedici.cocoon.acting.ClearCacheByGroupAction"/>
+        </map:actions>
+
     </map:components>
 
     <map:pipelines>
@@ -53,6 +58,9 @@ collections / items / and bitstreams.
 
             <!-- List all communities & collections in DSpace -->
             <map:match pattern="community-list">
+                    <map:match type="request" pattern="clearcache">
+                            <map:act type="ClearCacheByGroupAction"/>
+                    </map:match>
                     <map:transform type="CommunityBrowser">
                             <map:parameter name="depth" value="999"/>
                     </map:transform>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2134,7 +2134,11 @@ mirage2.item-view.bitstream.href.label.2 = title
 # this problem you can set the cache to be assumed valued for a specific set of time.
 # The downside of this is that new or editing communities/collections may not show up
 # the website for a period of time.
-#xmlui.community-list.cache = 12 hours
+xmlui.community-list.cache = 12 hours
+
+#Determinate which groups are allowed to execute the clearCache action
+#When creating, mofifying or deleting a Community/Collection
+xmlui.clearCacheGroups = CIC-ADMIN
 
 # Optionally you may configure Manakin to take advantage of metadata stored as a
 # bitstream. These metadata files should be inside the "METADATA" bundle and named

--- a/dspace/modules/xmlui/src/main/java/ar/unlp/sedici/cocoon/acting/ClearCacheByGroupAction.java
+++ b/dspace/modules/xmlui/src/main/java/ar/unlp/sedici/cocoon/acting/ClearCacheByGroupAction.java
@@ -1,0 +1,43 @@
+package ar.unlp.sedici.cocoon.acting;
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.acting.ClearCacheAction;
+import org.apache.cocoon.environment.Redirector;
+import org.apache.cocoon.environment.SourceResolver;
+import org.dspace.app.xmlui.utils.ContextUtil;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.Context;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+import java.util.Map;
+
+/**
+ * Simple action which ensures the cache is cleared of all
+ * cached results with security checks
+ */
+
+public class ClearCacheByGroupAction extends ClearCacheAction {
+
+    public Map act(Redirector redirector,
+                    SourceResolver resolver,
+                    Map objectModel,
+                    String src,
+                    Parameters par
+    ) throws Exception {
+        Context context = ContextUtil.obtainContext(objectModel);
+        GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+        AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
+        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        String[] clearCacheGroups = configurationService.getArrayProperty("xmlui.clearCacheGroups");
+
+        for (int i=0; i < clearCacheGroups.length; i++) {
+            if (authorizeService.isAdmin(context) || groupService.isMember(context,clearCacheGroups[i]))
+                return super.act(redirector, resolver, objectModel, src, par);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
    Se limpia cada vez que se agrega, elimina o modifica una comunidad o coleccion.
    Cualquier usuario Administrator o CIC-ADMIN puede limpiar la cache pasando como parametro a la url del arbol de comunidades  ?clearcache=true.
    Se agregó una clase ClearCacheByGroupAction que se encarga de realizar la limpieza, teniendo en cuenta si el usuario pertenece a ciertos grupos
    Los grupos habilitados para realizar esta accion se listan en la propiedad xmlui.clearCacheGroups, en dspace.cfg