### PR TITLE
-#4977 Se actualizó la versión de PDFBOX a la 2.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1181,12 +1181,12 @@
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>fontbox</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
 	        <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1181,12 +1181,12 @@
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.8</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>fontbox</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.8</version>
             </dependency>
             <dependency>
 	        <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
Para solucionar "java.lang.IllegalArgumentException: Symbolic fonts must have a built-in encoding" cuando el encoding del pdf no es valido.