### PR TITLE
 "#4854" Solución al remove del item, pasando GoogleMetadataTest

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -174,10 +174,10 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
     public void removeBitstream(Context context, Bundle bundle, Bitstream bitstream) throws AuthorizeException, SQLException, IOException {
         // Check authorisation
         authorizeService.authorizeAction(context, bundle, Constants.REMOVE);
+        authorizeService.authorizeAction(context, bitstream, Constants.DELETE);
 
         log.info(LogManager.getHeader(context, "remove_bitstream",
                 "bundle_id=" + bundle.getID() + ",bitstream_id=" + bitstream.getID()));
-
 
         context.addEvent(new Event(Event.REMOVE, Constants.BUNDLE, bundle.getID(),
                 Constants.BITSTREAM, bitstream.getID(), String.valueOf(bitstream.getSequenceID()),
@@ -443,6 +443,7 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
 
         // Remove bitstreams
         List<Bitstream> bitstreams = bundle.getBitstreams();
+        bundle.clearBitstreams();
         for (Bitstream bitstream : bitstreams) {
             removeBitstream(context, bundle, bitstream);
         }


### PR DESCRIPTION
 Se volvió a agregar la línea que limpiaba los bitstream del bundle, buscando poder eliminar items. Se agregó una verificación de permisos antes eliminar el bitstream.

La verdad no tengo bien en claro que es lo que cambia, que hace que no salte el 

`Authorization denied for action OBSOLETE (DELETE) on BITSTREAM...`

Empecé a dudar que la línea que había borrado @santit96 fuese la solución y empece a pensarlo mas como un problema de autorización. Ademas vi que esa línea (la que borraba los bitstream del bundle), estaba por todos lados, así que duda aún mas de que fuese LA solución. El origen de esa línea viene por acá https://jira.duraspace.org/browse/DS-2728, junto con las referencias entre Bundles y Bitstreams.

Estaría bueno ver si  alguno @FacundoAdorno  o @santit96 entiende que es lo que pasa con el contexto, (que es lo único que parece haber cambiado) como para hacer el PR a DSpace y tener argumentos un poco mas sólidos que decir "salio de pedo"

