### PR TITLE
-#5022 Se normalizó la búsqueda con paréntesis en ChoiceAuthorities

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -95,7 +95,7 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 			int limit) {
 
 		parameterizedSparqlString.setParams(globalParameters);
-		Query query = QueryFactory.create(parameterizedSparqlString.toString(),
+		Query query = QueryFactory.create(normalizeTextForHttpQuery(parameterizedSparqlString),
 				this.getSPARQLSyntax());
 		query.setOffset(offset);
 
@@ -129,6 +129,17 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 		return Syntax.syntaxSPARQL_10;
 	}
 
+	private String normalizeTextForHttpQuery(ParameterizedSparqlString parameterizedSparqlString) {
+		String query = parameterizedSparqlString.toString();
+		if (query.indexOf("\\(") >= 0) query = query.replace("\\(", "\\\\\\(");
+		if (query.indexOf("\\)") >= 0) query = query.replace("\\)", "\\\\\\)");
+		return query;
+	}
 
+	protected String normalizeTextForParserSPARQL10(String text) {
+		if (text.indexOf("(") >= 0) text = text.replace("(", "\\\\(");
+		if (text.indexOf(")") >= 0) text = text.replace(")", "\\\\)");
+		return text;
+	}
 
 }

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -95,7 +95,7 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 			int limit) {
 
 		parameterizedSparqlString.setParams(globalParameters);
-		Query query = QueryFactory.create(normalizeTextForHttpQuery(parameterizedSparqlString),
+		Query query = QueryFactory.create(normalizeTextForHttpQuery(parameterizedSparqlString.toString()),
 				this.getSPARQLSyntax());
 		query.setOffset(offset);
 
@@ -129,16 +129,23 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 		return Syntax.syntaxSPARQL_10;
 	}
 
-	private String normalizeTextForHttpQuery(ParameterizedSparqlString parameterizedSparqlString) {
-		String query = parameterizedSparqlString.toString();
-		if (query.indexOf("\\(") >= 0) query = query.replace("\\(", "\\\\\\(");
-		if (query.indexOf("\\)") >= 0) query = query.replace("\\)", "\\\\\\)");
+	private String normalizeTextForHttpQuery(String query) {
+		if (query.indexOf("\\(") >= 0) {
+			query = query.replace("\\(", "\\\\\\(");
+		}
+		if (query.indexOf("\\)") >= 0) {
+			query = query.replace("\\)", "\\\\\\)");
+		}
 		return query;
 	}
 
 	protected String normalizeTextForParserSPARQL10(String text) {
-		if (text.indexOf("(") >= 0) text = text.replace("(", "\\\\(");
-		if (text.indexOf(")") >= 0) text = text.replace(")", "\\\\)");
+		if (text.indexOf("(") >= 0) {
+			text = text.replace("(", "\\\\(");
+		}
+		if (text.indexOf(")") >= 0) {
+			text = text.replace(")", "\\\\)");
+		}
 		return text;
 	}
 

--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Author_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/Author_CICBA_Authority.java
@@ -91,6 +91,7 @@ public class Author_CICBA_Authority extends SPARQLAuthorityProvider {
 	protected ParameterizedSparqlString getSparqlSearchByTextQuery(
 			String field, String text, String locale) {
 		ParameterizedSparqlString pqs = new ParameterizedSparqlString();
+		text = normalizeTextForParserSPARQL10(text);
 
 		pqs.setNsPrefix("foaf", NS_FOAF);
 		pqs.setNsPrefix("dc", NS_DC);

--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/General_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/General_CICBA_Authority.java
@@ -68,6 +68,7 @@ public class General_CICBA_Authority extends SPARQLAuthorityProvider {
 			pqs.setLiteral("key", filter);
 		}
 		else {
+			filter = normalizeTextForParserSPARQL10(filter);
 			getTextFilterQuery(pqs,filter);
 			pqs.append("}\n");
 			pqs.append("ORDER BY ASC(?label)\n");


### PR DESCRIPTION
Al parsear parentesis en la búsqueda de tesauros, se rompía la clase com.hp.hpl.jena.sparql.lang.ParserSPARQL10.java.
Por lo que se escaparon correctamente los paréntesis en las consultas sparql de las subclases de SPARQLAuthorityProvider. También al momento de realizar la consulta http a Drupal.