### PR TITLE
DS-3542: Only trust X-Forwared-For headers from trusted proxies

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/IPAuthentication.java
@@ -19,13 +19,14 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections.ListUtils;
 import org.apache.log4j.Logger;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
+import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
+import org.dspace.service.ClientInfoService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
@@ -61,6 +62,7 @@ public class IPAuthentication implements AuthenticationMethod
     protected List<IPMatcher> ipNegativeMatchers;
 
     protected GroupService groupService;
+    protected ClientInfoService clientInfoService;
 
     
     /**
@@ -84,6 +86,7 @@ public class IPAuthentication implements AuthenticationMethod
         ipMatcherGroupIDs = new HashMap<>();
         ipMatcherGroupNames = new HashMap<>();
         groupService = EPersonServiceFactory.getInstance().getGroupService();
+        clientInfoService = CoreServiceFactory.getInstance().getClientInfoService();
 
         List<String> propNames = DSpaceServicesFactory.getInstance().getConfigurationService().getPropertyKeys("authentication-ip");
 
@@ -181,21 +184,7 @@ public class IPAuthentication implements AuthenticationMethod
         List<Group> groups = new ArrayList<Group>();
 
         // Get the user's IP address
-        String addr = request.getRemoteAddr();
-        if (useProxies == null) {
-            useProxies = ConfigurationManager.getBooleanProperty("useProxies", false);
-        }
-        if (useProxies && request.getHeader("X-Forwarded-For") != null)
-        {
-            /* This header is a comma delimited list */
-            for(String xfip : request.getHeader("X-Forwarded-For").split(","))
-            {
-                if(!request.getHeader("X-Forwarded-For").contains(addr))
-                {
-                    addr = xfip.trim();
-                }
-            }
-        }
+        String addr = clientInfoService.getClientIp(request);
 
         for (IPMatcher ipm : ipMatchers)
         {

--- a/dspace-api/src/main/java/org/dspace/core/factory/CoreServiceFactory.java
+++ b/dspace-api/src/main/java/org/dspace/core/factory/CoreServiceFactory.java
@@ -10,6 +10,7 @@ package org.dspace.core.factory;
 import org.dspace.core.service.LicenseService;
 import org.dspace.core.service.NewsService;
 import org.dspace.core.service.PluginService;
+import org.dspace.service.ClientInfoService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
@@ -25,8 +26,10 @@ public abstract class CoreServiceFactory {
 
     public abstract PluginService getPluginService();
 
-    public static CoreServiceFactory getInstance()
-    {
-        return DSpaceServicesFactory.getInstance().getServiceManager().getServiceByName("coreServiceFactory", CoreServiceFactory.class);
+    public abstract ClientInfoService getClientInfoService();
+
+    public static CoreServiceFactory getInstance() {
+        return DSpaceServicesFactory.getInstance().getServiceManager()
+                                    .getServiceByName("coreServiceFactory", CoreServiceFactory.class);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/factory/CoreServiceFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/factory/CoreServiceFactoryImpl.java
@@ -10,6 +10,7 @@ package org.dspace.core.factory;
 import org.dspace.core.service.LicenseService;
 import org.dspace.core.service.NewsService;
 import org.dspace.core.service.PluginService;
+import org.dspace.service.ClientInfoService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -28,6 +29,9 @@ public class CoreServiceFactoryImpl extends CoreServiceFactory {
     @Autowired(required = true)
     private PluginService pluginService;
 
+    @Autowired(required = true)
+    private ClientInfoService clientInfoService;
+
     @Override
     public LicenseService getLicenseService() {
         return licenseService;
@@ -41,5 +45,9 @@ public class CoreServiceFactoryImpl extends CoreServiceFactory {
     @Override
     public PluginService getPluginService() {
         return pluginService;
+    }
+
+    public ClientInfoService getClientInfoService() {
+        return clientInfoService;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
+++ b/dspace-api/src/main/java/org/dspace/google/GoogleRecorderEventListener.java
@@ -17,12 +17,14 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
 import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Constants;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.service.ClientInfoService;
+import org.dspace.services.ConfigurationService;
 import org.dspace.services.model.Event;
 import org.dspace.usage.AbstractUsageEventListener;
 import org.dspace.usage.UsageEvent;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -46,12 +48,28 @@ public class GoogleRecorderEventListener extends AbstractUsageEventListener {
     private CloseableHttpClient httpclient;
     private String GoogleURL = "https://www.google-analytics.com/collect";
     private static Logger log = Logger.getLogger(GoogleRecorderEventListener.class);
-    protected ContentServiceFactory contentServiceFactory = ContentServiceFactory.getInstance();
-
+    protected ContentServiceFactory contentServiceFactory;
+    protected ConfigurationService configurationService;
+    protected ClientInfoService clientInfoService;
 
     public GoogleRecorderEventListener() {
         // httpclient is threadsafe so we only need one.
         httpclient = HttpClients.createDefault();
+    }
+
+    @Autowired
+    public void setContentServiceFactory(ContentServiceFactory contentServiceFactory) {
+        this.contentServiceFactory = contentServiceFactory;
+    }
+
+    @Autowired
+    public void setConfigurationService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    @Autowired
+    public void setClientInfoService(ClientInfoService clientInfoService) {
+        this.clientInfoService = clientInfoService;
     }
 
     @Override
@@ -172,21 +190,7 @@ public class GoogleRecorderEventListener extends AbstractUsageEventListener {
     }
 
     private String getIPAddress(HttpServletRequest request) {
-        String clientIP = request.getRemoteAddr();
-        if (ConfigurationManager.getBooleanProperty("useProxies", false) && request.getHeader("X-Forwarded-For") != null) {
-            /* This header is a comma delimited list */
-            for (String xfip : request.getHeader("X-Forwarded-For").split(",")) {
-                /* proxy itself will sometime populate this header with the same value in
-                    remote address. ordering in spec is vague, we'll just take the last
-                    not equal to the proxy
-                */
-                if (!request.getHeader("X-Forwarded-For").contains(clientIP)) {
-                    clientIP = xfip.trim();
-                }
-            }
-        }
-
-        return clientIP;
+        return clientInfoService.getClientIp(request);
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/service/ClientInfoService.java
+++ b/dspace-api/src/main/java/org/dspace/service/ClientInfoService.java
@@ -1,0 +1,37 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.service;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Service that can be used to retrieve information about DSpace clients
+ */
+public interface ClientInfoService {
+
+    /**
+     * Get the client IP of this request taking into account the X-Forwarded-For header and the "useProxies" setting
+     * @param request The client HTTP request
+     * @return The IP address of the originating client
+     */
+    String getClientIp(HttpServletRequest request);
+
+    /**
+     * Get the client IP of this request taking into account the X-Forwarded-For header and the "useProxies" setting
+     * @param remoteIp the remote address of the current request
+     * @param xForwardedForHeaderValue The value of the X-Forwarded-For header
+     * @return The IP address of the originating client
+     */
+    String getClientIp(String remoteIp, String xForwardedForHeaderValue);
+
+    /**
+     * Does DSpace take into account HTTP proxy headers or not
+     * @return true if this is the case, false otherwise
+     */
+    boolean isUseProxiesEnabled();
+}

--- a/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
@@ -112,6 +112,7 @@ public class ClientInfoServiceImpl implements ClientInfoService {
         /* This header is a comma delimited list */
         String headerValue = StringUtils.trimToEmpty(xForwardedForValue);
         for (String xfip : headerValue.split(",")) {
+            xfip = xfip.trim();
             /* proxy itself will sometime populate this header with the same value in
                remote address. ordering in spec is vague, we'll just take the last
                not equal to the proxy
@@ -120,7 +121,7 @@ public class ClientInfoServiceImpl implements ClientInfoService {
                     //if we have trusted proxies, we'll assume that they are not the client IP
                     && (trustedProxies == null || !isRequestFromTrustedProxy(xfip))) {
 
-                ip = xfip.trim();
+                ip = xfip;
             }
         }
 

--- a/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
@@ -1,0 +1,129 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.service.impl;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.service.ClientInfoService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.statistics.util.IPTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Implementation of {@link ClientInfoService} that can provide information on DSpace client requests
+ */
+public class ClientInfoServiceImpl implements ClientInfoService {
+
+    private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+
+    private static final Logger log = LoggerFactory.getLogger(ClientInfoServiceImpl.class);
+
+    private Boolean useProxiesEnabled;
+
+    private ConfigurationService configurationService;
+
+    /**
+     * Sparse HashTable structure to hold IP address ranges of trusted proxies
+     */
+    private IPTable trustedProxies;
+
+    @Autowired(required = true)
+    public ClientInfoServiceImpl(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.trustedProxies = parseTrustedProxyRanges(
+                configurationService.getArrayProperty("proxies.trusted.ipranges"));
+    }
+
+    @Override
+    public String getClientIp(HttpServletRequest request) {
+        return getClientIp(request.getRemoteAddr(), request.getHeader(X_FORWARDED_FOR_HEADER));
+    }
+
+    @Override
+    public String getClientIp(String remoteIp, String xForwardedForHeaderValue) {
+        String ip = remoteIp;
+
+        if (isUseProxiesEnabled()) {
+            String xForwardedForIp = getXForwardedForIpValue(remoteIp, xForwardedForHeaderValue);
+
+            if (StringUtils.isNotBlank(xForwardedForIp) && isRequestFromTrustedProxy(ip)) {
+                ip = xForwardedForIp;
+            }
+
+        } else if (StringUtils.isNotBlank(xForwardedForHeaderValue)) {
+            log.warn(
+                    "X-Forwarded-For header detected but useProxiesEnabled is not enabled. " +
+                            "If your dspace is behind a proxy set it to true");
+        }
+
+        return ip;
+    }
+
+    @Override
+    public boolean isUseProxiesEnabled() {
+        if (useProxiesEnabled == null) {
+            useProxiesEnabled = configurationService.getBooleanProperty("useProxies", true);
+            log.info("useProxies=" + useProxiesEnabled);
+        }
+
+        return useProxiesEnabled;
+    }
+
+    private IPTable parseTrustedProxyRanges(String[] proxyProperty) {
+        if (ArrayUtils.isEmpty(proxyProperty)) {
+            return null;
+        } else {
+            //Load all supplied proxy IP ranges into the IP table
+            IPTable ipTable = new IPTable();
+            try {
+                for (String proxyRange : proxyProperty) {
+                    ipTable.add(proxyRange);
+                }
+            } catch (IPTable.IPFormatException e) {
+                log.error("Property proxies.trusted.ipranges contains an invalid IP range", e);
+                ipTable = null;
+            }
+
+            return ipTable;
+        }
+    }
+
+    private boolean isRequestFromTrustedProxy(String ipAddress) {
+        try {
+            return trustedProxies == null || trustedProxies.contains(ipAddress);
+        } catch (IPTable.IPFormatException e) {
+            log.error("Request contains invalid remote address", e);
+            return false;
+        }
+    }
+
+    private String getXForwardedForIpValue(String remoteIp, String xForwardedForValue) {
+        String ip = null;
+
+        /* This header is a comma delimited list */
+        String headerValue = StringUtils.trimToEmpty(xForwardedForValue);
+        for (String xfip : headerValue.split(",")) {
+            /* proxy itself will sometime populate this header with the same value in
+               remote address. ordering in spec is vague, we'll just take the last
+               not equal to the proxy
+            */
+            if (!StringUtils.equals(remoteIp, xfip) && StringUtils.isNotBlank(xfip)
+                    //if we have trusted proxies, we'll assume that they are not the client IP
+                    && (trustedProxies == null || !isRequestFromTrustedProxy(xfip))) {
+
+                ip = xfip.trim();
+            }
+        }
+
+        return ip;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -9,8 +9,8 @@ package org.dspace.statistics.util;
 
 import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.lang.StringUtils;
+import org.dspace.service.ClientInfoService;
 import org.dspace.services.ConfigurationService;
-import org.dspace.services.factory.DSpaceServicesFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,8 +37,6 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
 
     private static final Logger log = LoggerFactory.getLogger(SpiderDetectorServiceImpl.class);
 
-    private Boolean useProxies;
-
     private Boolean useCaseInsensitiveMatching;
 
     private final List<Pattern> agents
@@ -48,6 +46,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
             = Collections.synchronizedList(new ArrayList<Pattern>());
 
     private ConfigurationService configurationService;
+    private ClientInfoService clientInfoService;
 
     /**
      * Sparse HashTable structure to hold IP address ranges.
@@ -55,8 +54,9 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
     private IPTable table = null;
 
     @Autowired(required = true)
-    public SpiderDetectorServiceImpl(ConfigurationService configurationService) {
+    public SpiderDetectorServiceImpl(ConfigurationService configurationService, ClientInfoService clientInfoService) {
         this.configurationService = configurationService;
+        this.clientInfoService = clientInfoService;
     }
 
     public IPTable getTable() {
@@ -102,7 +102,7 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
         }
 
         // No.  See if any IP addresses match
-        if (isUseProxies() && proxyIPs != null) {
+        if (clientInfoService.isUseProxiesEnabled() && proxyIPs != null) {
             /* This header is a comma delimited list */
             for (String xfip : proxyIPs.split(",")) {
                 if (isSpider(xfip))
@@ -316,14 +316,6 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
         }
 
         return useCaseInsensitiveMatching;
-    }
-
-    private boolean isUseProxies() {
-        if(useProxies == null) {
-            useProxies = configurationService.getBooleanProperty("useProxies");
-        }
-
-        return useProxies;
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/MockSolrLoggerServiceImpl.java
@@ -38,7 +38,6 @@ public class MockSolrLoggerServiceImpl
         File locationDb = new File(locationDbPath);
         locationDb.createNewFile();
         locationService = new DatabaseReader.Builder(locationDb).build();
-        useProxies = configurationService.getBooleanProperty("useProxies");
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/statistics/util/SpiderDetectorServiceImplTest.java
@@ -11,6 +11,8 @@ package org.dspace.statistics.util;
 import mockit.Mock;
 import mockit.MockUp;
 import org.dspace.AbstractDSpaceTest;
+import org.dspace.core.factory.CoreServiceFactory;
+import org.dspace.service.ClientInfoService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.statistics.SolrLoggerServiceImpl;
@@ -37,14 +39,15 @@ public class SpiderDetectorServiceImplTest extends AbstractDSpaceTest
 
     private ConfigurationService configurationService;
 
+    private ClientInfoService clientInfoService;
 
     private SpiderDetectorService spiderDetectorService;
 
     @Before
     public void init() {
         configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
-        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService);
-
+        clientInfoService = CoreServiceFactory.getInstance().getClientInfoService();
+        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService, clientInfoService);
     }
 
     @Test
@@ -67,7 +70,7 @@ public class SpiderDetectorServiceImplTest extends AbstractDSpaceTest
     public void testCaseInsensitiveMatching() throws Exception
     {
         configurationService.setProperty("usage-statistics.bots.case-insensitive", true);
-        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService);
+        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService, clientInfoService);
 
         DummyHttpServletRequest req = new DummyHttpServletRequest();
         req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
@@ -273,7 +276,7 @@ public class SpiderDetectorServiceImplTest extends AbstractDSpaceTest
     public void testBothLowerAndUpperCaseGetMatched() {
 
         configurationService.setProperty("usage-statistics.bots.case-insensitive", true);
-        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService);
+        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService, clientInfoService);
 
         DummyHttpServletRequest req = new DummyHttpServletRequest();
         req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises
@@ -305,7 +308,7 @@ public class SpiderDetectorServiceImplTest extends AbstractDSpaceTest
     @Test
     public void testNonBooleanConfig() {
         configurationService.setProperty("usage-statistics.bots.case-insensitive", "RandomNonBooleanString");
-        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService);
+        spiderDetectorService = new SpiderDetectorServiceImpl(configurationService, clientInfoService);
 
         DummyHttpServletRequest req = new DummyHttpServletRequest();
         req.setAddress(NOT_A_BOT_ADDRESS); // avoid surprises

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -328,7 +328,16 @@ http.proxy.port =
 
 # If enabled, the logging and the Solr statistics system will look for
 # an X-Forwarded-For header. If it finds it, it will use this for the user IP address
-#useProxies = true
+useProxies = true
+
+# If "useProxies" is enabled, the authentication and statistics logging code will read the X-Forwarded-For header in
+# order to determine the correct client IP address. But they will only use that header value when the request is coming
+# from a trusted proxy server location (e.g. HTTPD on localhost). Leave this property empty to trust X-Forwarded-For
+# values of all requests. You can specify a range by only listing the first three ip-address blocks, e.g. 128.177.243
+# You can list multiple IP addresses or ranges by comma-separating them.
+# If you are running REST & UI on different servers, you should add the UI servers (range) as a proxy.
+# For example : proxies.trusted.ipranges = 127.0.0.1, 192.168.2
+proxies.trusted.ipranges = 127.0.0.1
 
 #### Media Filter / Format Filter plugins (through PluginService) ####
 # Media/Format Filters help to full-text index content or

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -97,6 +97,7 @@
     <bean id="solrLoggerService" class="org.dspace.statistics.SolrLoggerServiceImpl" lazy-init="true"/>
 
     <bean id="spiderDetectorService" class="org.dspace.statistics.util.SpiderDetectorServiceImpl"/>
+    <bean id="clientInfoService" class="org.dspace.service.impl.ClientInfoServiceImpl"/>
 
     <bean class="org.dspace.versioning.VersionHistoryServiceImpl"/>
 


### PR DESCRIPTION
Ticket#4937, Se hizo un cherry-pick del commit  https://github.com/DSpace/DSpace/commit/bd464e03f51311af705ed3ac58f83b0399416fc9 para no permitir que un bot bypasee el filtro de bots usando un x-forwarded-for falso, y así no registrar en Google Analytics información de eventos de descargas generados por bots.

Este commit hace que se valide la ip del cliente antes de confiar en el x-forwarded-for, asi solo se reenvian ips de clientes que pasan por proxies avalados y no ips de "clientes" (que pueden no serlo) de cualquier ip que diga ser un proxy