### PR TITLE
-#5040 Creé tres configuaciones propias de cic para la tarea de curation metadataauthorityqualitycontrol

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2257,6 +2257,7 @@ include = ${module_dir}/authentication-password.cfg
 include = ${module_dir}/authentication-shibboleth.cfg
 include = ${module_dir}/authentication-x509.cfg
 include = ${module_dir}/bulkedit.cfg
+include = ${module_dir}/cic-metadataauthorityqualitycontrol.cfg
 include = ${module_dir}/citation-page.cfg
 include = ${module_dir}/clamav.cfg
 include = ${module_dir}/controlpanel.cfg

--- a/dspace/config/modules/cic-metadataauthorityqualitycontrol.cfg
+++ b/dspace/config/modules/cic-metadataauthorityqualitycontrol.cfg
@@ -8,7 +8,7 @@ metadataauthorityqualitycontrol.fixInvalidAuthorities.fixmode = true
 metadataauthorityqualitycontrol.fixInvalidAuthorities.fixMissing = true
 metadataauthorityqualitycontrol.fixInvalidAuthorities.fixDangling = true
 metadataauthorityqualitycontrol.fixInvalidAuthorities.checkMetadata = *
-metadataauthorityqualitycontrol.fixInvalidAuthorities.skipMetadata = dcterms.isPartOf.item, dcterms.isPartOf.issue, dcterms.relation, dcterms.hasPart, dcterms.isVersionOf, dcterms.identifier.url
+metadataauthorityqualitycontrol.fixInvalidAuthorities.skipMetadata = dcterms_isPartOf_item, dcterms_isPartOf_issue, dcterms_relation, dcterms_hasPart, dcterms_isVersionOf, dcterms_identifier_url
 
 #metadataauthorityqualitycontrol.checkRequiredAuthorities, reporta los errores.
 #Siempre se debe ejecutar luego del la fixInvalidAuthorities

--- a/dspace/config/modules/cic-metadataauthorityqualitycontrol.cfg
+++ b/dspace/config/modules/cic-metadataauthorityqualitycontrol.cfg
@@ -1,0 +1,23 @@
+#----------------------------------------------------------------------------------#
+#--- CONFIGURACIONES CIC DE LA TAREA DE CURATION METADATAAUTORITYQUALITYCONTROL ---#
+#----------------------------------------------------------------------------------#
+
+#metadataauthorityqualitycontrol.fixInvalidAuthorities, arregla los casos de autoridad faltante
+plugin.named.org.dspace.curate.CurationTask = ar.edu.unlp.sedici.dspace.ctask.general.MetadataAuthorityQualityControl = metadataauthorityqualitycontrol.fixInvalidAuthorities
+metadataauthorityqualitycontrol.fixInvalidAuthorities.fixmode = true
+metadataauthorityqualitycontrol.fixInvalidAuthorities.fixMissing = true
+metadataauthorityqualitycontrol.fixInvalidAuthorities.fixDangling = true
+metadataauthorityqualitycontrol.fixInvalidAuthorities.checkMetadata = *
+metadataauthorityqualitycontrol.fixInvalidAuthorities.skipMetadata = dcterms.isPartOf.item, dcterms.isPartOf.issue, dcterms.relation, dcterms.hasPart, dcterms.isVersionOf, dcterms.identifier.url
+
+#metadataauthorityqualitycontrol.checkRequiredAuthorities, reporta los errores.
+#Siempre se debe ejecutar luego del la fixInvalidAuthorities
+plugin.named.org.dspace.curate.CurationTask = ar.edu.unlp.sedici.dspace.ctask.general.MetadataAuthorityQualityControl = metadataauthorityqualitycontrol.checkRequiredAuthorities
+metadataauthorityqualitycontrol.checkRequiredAuthorities.fixmode = false
+metadataauthorityqualitycontrol.checkRequiredAuthorities.checkMetadata = dc_type, dcterms_language ,dcterms_subject_area
+
+#metadataauthorityqualitycontrol.fixClosedAuthorities, se eliminan las variantes de los metadatos authority closed
+plugin.named.org.dspace.curate.CurationTask = ar.edu.unlp.sedici.dspace.ctask.general.MetadataAuthorityQualityControl = metadataauthorityqualitycontrol.fixClosedAuthorities
+metadataauthorityqualitycontrol.fixClosedAuthorities.fixmode = true
+metadataauthorityqualitycontrol.fixClosedAuthorities.fixVariants = true
+metadataauthorityqualitycontrol.fixClosedAuthorities.checkMetadata = dcterms_subject_materia, dc_type, dcterms_language, dcterms_license, dcterms_subject_area


### PR DESCRIPTION
También creé el nuevo archivo de configuración cic-metadataauthorityqualitycontrol.cfg, y agregué ahí las configuraciones.
Estas serían:
 

- metadataauthorityqualitycontrol.fixInvalidAuthorities, arregla los casos de autoridad faltante

    `plugin.named.org.dspace.curate.CurationTask = ar.edu.unlp.sedici.dspace.ctask.general.MetadataAuthorityQualityControl = metadataauthorityqualitycontrol.fixInvalidAuthorities`

`metadataauthorityqualitycontrol.fixInvalidAuthorities.fixmode = true
 metadataauthorityqualitycontrol.fixInvalidAuthorities.fixMissing = true
metadataauthorityqualitycontrol.fixInvalidAuthorities.fixDangling = true
 metadataauthorityqualitycontrol.fixInvalidAuthorities.checkMetadata = *
 metadataauthorityqualitycontrol.fixInvalidAuthorities.skipMetadata = dcterms.isPartOf.item, dcterms.isPartOf.issue, dcterms.relation, dcterms.hasPart, dcterms.isVersionOf, dcterms.identifier.url
`

- metadataauthorityqualitycontrol.checkRequiredAuthorities, reporta los errores. Siempre se debe ejecutar luego del la fixInvalidAuthorities

`plugin.named.org.dspace.curate.CurationTask = ar.edu.unlp.sedici.dspace.ctask.general.MetadataAuthorityQualityControl = metadataauthorityqualitycontrol.checkRequiredAuthorities`

`metadataauthorityqualitycontrol.checkRequiredAuthorities.fixmode = false
 metadataauthorityqualitycontrol.checkRequiredAuthorities.checkMetadata = dc_type, dcterms_language ,dcterms_subject_area`
   
- metadataauthorityqualitycontrol.fixClosedAuthorities, se eliminan las variantes de los metadatos authority closed

   ` plugin.named.org.dspace.curate.CurationTask = ar.edu.unlp.sedici.dspace.ctask.general.MetadataAuthorityQualityControl = metadataauthorityqualitycontrol.fixClosedAuthorities`

`   metadataauthorityqualitycontrol.fixClosedAuthorities.fixmode = true
    metadataauthorityqualitycontrol.fixClosedAuthorities.fixVariants = true
    metadataauthorityqualitycontrol.fixClosedAuthorities.checkMetadata = dcterms_subject_materia, dc_type, dcterms_language, dcterms_license, dcterms_subject_area`

