### PR TITLE
-#5650 Ahora en las páginas de comunidades y colecciones las estadísicas de acceso se muestran considerando solo los accesos acumulados a los items pertenecientes a esa comunidad/coleccion

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/content/DatasetGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/DatasetGenerator.java
@@ -19,8 +19,8 @@ package org.dspace.statistics.content;
  */
 public abstract class DatasetGenerator {
     
-    /** The type of generator can either be CATEGORY or SERIE **/
-    protected int datasetType;
+    /** The type of object to search (item, bitstream, etc) **/
+    protected int datasetType = -1;
 
     protected boolean includeTotal = false;
 

--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -265,7 +265,7 @@ public class StatisticsDataVisits extends StatisticsData
 
             ObjectCount[] topCounts1 = null;
 //            if(firsDataset.getQueries().size() == 1){
-            topCounts1 = queryFacetField(firsDataset, firsDataset.getQueries().get(0).getQuery(), filterQuery);
+            topCounts1 = queryFacetField(firsDataset, firsDataset.getQueries().get(0).getQuery(), filterQuery, showTotal);
 //            }else{
 //                TODO: do this
 //            }
@@ -273,7 +273,7 @@ public class StatisticsDataVisits extends StatisticsData
             if(datasetQueries.size() == 2){
                 DatasetQuery secondDataSet = datasetQueries.get(1);
                 // Now do the second one
-                ObjectCount[] topCounts2 = queryFacetField(secondDataSet, secondDataSet.getQueries().get(0).getQuery(), filterQuery);
+                ObjectCount[] topCounts2 = queryFacetField(secondDataSet, secondDataSet.getQueries().get(0).getQuery(), filterQuery, showTotal);
                 // Now that have results for both of them lets do x.y queries
                 List<String> facetQueries = new ArrayList<String>();
                 for (ObjectCount count2 : topCounts2) {
@@ -456,7 +456,15 @@ public class StatisticsDataVisits extends StatisticsData
             Query query = new Query();
             if(currentDso != null)
             {
-                query.setDso(currentDso, currentDso.getType());
+                if (typeAxis.getDatasetType() > -1 && typeAxis.getDatasetType() != currentDso.getType()) {
+                    //We are looking for childrens of an object
+                    query.setOwningDso(currentDso);
+                    query.setDsoType(typeAxis.getDatasetType());
+                }
+                else {
+                    //Our type is our current object
+                    query.setDso(currentDso, currentDso.getType());
+                }
             }
             datasetQuery.addQuery(query);
 
@@ -676,12 +684,12 @@ public class StatisticsDataVisits extends StatisticsData
 
 
     protected ObjectCount[] queryFacetField(DatasetQuery dataset, String query,
-            String filterQuery) throws SolrServerException
+            String filterQuery, boolean showTotal) throws SolrServerException
     {
         String facetType = dataset.getFacetField() == null ? "id" : dataset
                 .getFacetField();
         return solrLoggerService.queryFacetField(query, filterQuery, facetType,
-                dataset.getMax(), false, null);
+                dataset.getMax(), showTotal, null);
     }
 
     public static class DatasetQuery {

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statistics/StatisticsTransformer.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/statistics/StatisticsTransformer.java
@@ -190,10 +190,11 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			statListing.setId("list1");
 
 			DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-			dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
+			dsoAxis.addDsoChild(Constants.ITEM, 1, false, -1);
+			dsoAxis.setIncludeTotal(true);
 			statListing.addDatasetGenerator(dsoAxis);
 
-			addDisplayListing(division, statListing);
+			addDisplayTotal(dso, division, statListing);
 
 		} catch (Exception e) {
 			log.error(
@@ -216,7 +217,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			statisticsTable.addDatasetGenerator(timeAxis);
 
 			DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
-			dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
+			dsoAxis.addDsoChild(Constants.ITEM, 10, false, -1);
 			statisticsTable.addDatasetGenerator(dsoAxis);
 
 			addDisplayTable(division, statisticsTable);
@@ -264,6 +265,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 
             DatasetTypeGenerator typeAxis = new DatasetTypeGenerator();
             typeAxis.setType("countryCode");
+            typeAxis.setDatasetType(Constants.ITEM);
             typeAxis.setMax(10);
             statListing.addDatasetGenerator(typeAxis);
 
@@ -287,6 +289,7 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 
             DatasetTypeGenerator typeAxis = new DatasetTypeGenerator();
             typeAxis.setType("city");
+            typeAxis.setDatasetType(Constants.ITEM);
             typeAxis.setMax(10);
             statListing.addDatasetGenerator(typeAxis);
 
@@ -422,6 +425,59 @@ public class StatisticsTransformer extends AbstractDSpaceTransformer {
 			}
 
 		}
+
+	}
+
+	private void addDisplayTotal(DSpaceObject dso, Division mainDiv, StatisticsListing display)
+				throws SAXException, WingException, SQLException,
+				SolrServerException, IOException, ParseException {
+
+			String title = display.getTitle();
+
+			Dataset dataset = display.getDataset();
+
+			if (dataset == null) {
+				/** activate dataset query */
+				dataset = display.getDataset(context);
+			}
+
+			if (dataset != null) {
+
+				String[][] matrix = dataset.getMatrix();
+
+				// String[] rLabels = dataset.getRowLabels().toArray(new String[0]);
+
+				Table table = mainDiv.addTable("list-table", matrix.length, 2,
+						title == null ? "detailtable" : "tableWithTitle detailtable");
+				if (title != null) {
+				    table.setHead(message(title));
+				}
+
+				Row headerRow = table.addRow();
+
+				headerRow.addCell("", Cell.ROLE_HEADER, "labelcell");
+
+				headerRow.addCell("", Cell.ROLE_HEADER, "labelcell").addContent(message(T_head_visits_views));
+
+				/** Generate Table Body */
+				int col = matrix[0].length -1 ;
+					Row valListRow = table.addRow();
+
+					Cell catCell = valListRow.addCell("1", Cell.ROLE_DATA,
+							"labelcell");
+					catCell.addContent(dso.getName());
+
+					Cell valCell = valListRow.addCell("2", Cell.ROLE_DATA,
+							"datacell");
+					valCell.addContent(matrix[0][col]);
+
+
+				if (!"".equals(display.getCss())) {
+					List attrlist = mainDiv.addList("divattrs");
+					attrlist.addItem("style", display.getCss());
+				}
+
+			}
 
 	}
 


### PR DESCRIPTION
Modifiqué las clases StatisticsDataVisit y DatasetGenerator de API para permitir la búsqueda en solr por los objetos hijo de una comunidad o colección
También agregué un método nuevo en StatisticsTransformer que muestra el total acumulado de visitas de forma correcta (antes se mostraba el acceso solo a la comunidad/coleccion y se discriminaba el acceso a la comunidad/coleccion con id legacy)