### PR TITLE
-#5714 Agrego manejo de las excepciones QueryExceptionHTTP y ExprException en la tarea de curation MetadataAuthorityQualityControl

### DIFF
--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/ctask/general/MetadataAuthorityQualityControl.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/ctask/general/MetadataAuthorityQualityControl.java
@@ -12,6 +12,8 @@ import org.dspace.curate.AbstractCurationTask;
 import org.dspace.curate.Curator;
 import java.io.IOException;
 import java.util.List;
+import com.hp.hpl.jena.sparql.engine.http.QueryExceptionHTTP;
+import com.hp.hpl.jena.sparql.expr.ExprException;
 
 /**
  * Curation task that checks each authority controlled metadata of an item, reports anomalies and optionally fix them
@@ -94,7 +96,12 @@ public class MetadataAuthorityQualityControl extends AbstractCurationTask {
 				//Only check metadata if it is authority controlled
 				if (authService.isAuthorityControlled(mv.getMetadataField()) && !skipMetadata(mv.getMetadataField())
 						&& isMetadataToCheck(mv.getMetadataField())) {
-					checkMetadataAuthority(reporter, mv, item);
+					try {
+						checkMetadataAuthority(reporter, mv, item);
+					} catch (ExprException | QueryExceptionHTTP e) {
+						report(reporter, mv, "ERROR", "An error ocurred processing metadata: ", e.getMessage());
+						e.printStackTrace();
+					}
 				}
 			}
 			report(reporter.toString());


### PR DESCRIPTION
Ahora si la tarea de curation falla porque un item tiene un metadato defectuoso o algún authority provider está caído, esta no para su execución sino que sigue con el próximo metadato.