### PR TITLE
-#5666 Limpiar expresiones regulares en los archivos de userAgent

### DIFF
--- a/dspace/config/spiders/agents/COUNTER_Robots_list.txt
+++ b/dspace/config/spiders/agents/COUNTER_Robots_list.txt
@@ -6,22 +6,22 @@ crawl
 ^IDA$
 ^ruby$
 ^voyager\/
-^@ozilla\/\d
+^\@ozilla\/[0-9]
 ^脝脝陆芒潞贸碌脛$
 ^破解后的$
 AddThis
 A6\-Indexer
 ADmantX
 alexa
-Alexandria(\s|\+)prototype(\s|\+)project
+Alexandria(\ |\+)prototype(\ |\+)project
 AllenTrack
 almaden
 appie
-API[\+\s]scraper
+API[\ \+]scraper
 Arachmo
 architext
 ArchiveTeam
-aria2\/\d
+aria2\/[0-9]
 arks
 ^Array$
 asterias
@@ -33,7 +33,7 @@ biglotron
 BingPreview
 binlar
 bjaaland
-Blackboard[\+\s]Safeassign
+Blackboard[\ \+]Safeassign
 blaiz\-bee
 bloglines
 blogpulse
@@ -47,12 +47,12 @@ celestial
 cfnetwork
 checklink
 checkprivacy
-China\sLocal\sBrowse\s2\.6
+China\ Local\ Browse\ 2\.6
 cloakDetect
 coccoc\/1\.0
-Code\sSample\sWeb\sClient
+Code\ Sample\ Web\ Client
 ColdFusion
-collection@infegy.com
+collection\@infegy.com
 com\.plumanalytics
 combine
 contentmatch
@@ -67,15 +67,15 @@ DataCha0s\/2\.0
 daumoa
 ^\%?default\%?$
 DeuSu\/
-Dispatch\/\d
+Dispatch\/[0-9]
 Docoloc
 docomo
 Download\+Master
 DSurf
 DTS Agent
-EasyBib[\+\s]AutoCite[\+\s]
+EasyBib[\ \+]AutoCite[\ \+]
 easydl
-EBSCO\sEJS\sContent\sServer
+EBSCO\ EJS\ Content\ Server
 ELinks\/
 EmailSiphon
 EmailWolf
@@ -83,12 +83,12 @@ Embedly
 EThOS\+\(British\+Library\)
 facebookexternalhit\/
 favorg
-FDM(\s|\+)\d
+FDM(\ |\+)[0-9]
 feedburner
 FeedFetcher
 feedreader
 ferret
-Fetch(\s|\+)API(\s|\+)Request
+Fetch(\ |\+)API(\ |\+)Request
 findlinks
 findthatfile
 ^FileDown$
@@ -102,7 +102,7 @@ GetRight
 geturl
 G-i-g-a-b-o-t
 GLMSLinkAnalysis
-Goldfire(\s|\+)Server
+Goldfire(\ |\+)Server
 google
 Grammarly
 grub
@@ -123,12 +123,12 @@ ichiro
 iktomi
 ilse
 Indy Library
-^integrity\/\d
+^integrity\/[0-9]
 internetseer
 intute
 iSiloX
 iskanie
-^java\/\d{1,2}.\d
+^Java\/[0-9]{1,2}.[0-9]
 jeeves
 jobo
 kyluka
@@ -150,13 +150,13 @@ LOCKSS
 LongURL.API
 ltx71
 lwp
-lycos[\_\+]
+lycos[_\+]
 mail.ru
 MarcEdit.5.2.Web.Client
 mediapartners\-google
 megite
-MetaURI[\+\s]API\/\d\.\d
-Microsoft(\s|\+)URL(\s|\+)Control
+MetaURI[\ \+]API\/[0-9]\.[0-9]
+Microsoft(\ |\+)URL(\ |\+)Control
 Microsoft Office Existence Discovery
 Microsoft Office Protocol Discovery
 Microsoft-WebDAV-MiniRedir
@@ -172,12 +172,12 @@ motor
 ^Mozilla.5\.0$
 ^Mozilla\/5.0\+\(compatible;\+MSIE\+6\.0;\+Windows\+NT\+5\.0\)$
 ^Mozilla\/5\.0\+like\+Gecko$
-^Mozilla\/5.0(\s|\+)Gecko\/20100115(\s|\+)Firefox\/3.6$
+^Mozilla\/5.0(\ |\+)Gecko\/20100115(\ |\+)Firefox\/3.6$
 ^MSIE
 MuscatFerre
 myweb
 nagios
-^NetAnts\/\d
+^NetAnts\/[0-9]
 netcraft
 netluchs
 ng\/2\.
@@ -187,7 +187,7 @@ nomad
 nutch
 ^oaDOI$
 ocelli
-Offline(\s|\+)Navigator
+Offline(\ |\+)Navigator
 ^okhttp$
 onetszukaj
 ^Opera\/4$
@@ -201,7 +201,7 @@ PHP\/
 pioneer
 playmusic\.com
 playstarmusic\.com
-^Postgenomic(\s|\+)v2
+^Postgenomic(\ |\+)v2
 powermarks
 proximic
 PycURL
@@ -217,8 +217,8 @@ scan4mail
 scientificcommons
 scirus
 scooter
-Scrapy\/\d
-^scrutiny\/\d
+Scrapy\/[0-9]
+^scrutiny\/[0-9]
 SearchBloxIntra
 shoutcast
 SkypeUriPreview
@@ -231,7 +231,7 @@ sunrise
 Sysomos
 T\-H\-U\-N\-D\-E\-R\-S\-T\-O\-N\-E
 tailrank
-Teleport(\s|\+)Pro
+Teleport(\ |\+)Pro
 Teoma
 The\+Knowledge\+AI
 titan
@@ -253,7 +253,7 @@ voila
 voyager\/
 w3af.org
 Wanadoo
-Web(\s|\+)Downloader
+Web(\ |\+)Downloader
 WebCloner
 webcollage
 WebCopier

--- a/dspace/config/spiders/agents/example
+++ b/dspace/config/spiders/agents/example
@@ -1,7 +1,7 @@
 Mozilla\/5\.0 \(compatible; PRTG Network Monitor \(www\.paessler\.com\); Windows\)
 Mozilla\/5\.0 \(compatible; monitis \- premium monitoring service; http:\/\/www\.monitis\.com\)
 Pingdom\.com_bot_version_1\.4_\(http:\/\/www\.pingdom\.com\/\)
-Alexandria(\s|\+)prototype(\s|\+)project
+Alexandria(\ |\+)prototype(\ |\+)project
 AllenTrack
 Arachmo
 Brutus\/AET
@@ -13,30 +13,30 @@ DataCha0s\/2\.0
 Demo\sBot
 EmailSiphon
 EmailWolf
-FDM(\s|\+)1
-Fetch(\s|\+)API(\s|\+)Request
+FDM(\ |\+)1
+Fetch(\ |\+)API(\ |\+)Request
 GetRight
-Goldfire(\s|\+)Server
+Goldfire(\ |\+)Server
 Googlebot
 HTTrack
 LOCKSS
 LWP\:\:Simple
 MSNBot
-Microsoft(\s|\+)URL(\s|\+)Control
+Microsoft(\ |\+)URL(\ |\+)Control
 Milbot
 MuscatFerre
 NABOT
 NaverBot
-Offline(\s|\+)Navigator
+Offline(\ |\+)Navigator
 OurBrowser
 Python\-urllib
 Readpaper
 Strider
 T\-H\-U\-N\-D\-E\-R\-S\-T\-O\-N\-E
-Teleport(\s|\+)Pro
+Teleport(\ |\+)Pro
 Teoma
 Wanadoo
-Web(\s|\+)Downloader
+Web(\ |\+)Downloader
 WebCloner
 WebCopier
 WebReaper
@@ -45,7 +45,7 @@ WebZIP
 Webinator
 Webmetrics
 Wget
-Xenu(\s|\+)Link(\s|\+)Sleuth
+Xenu(\ |\+)Link(\ |\+)Sleuth
 #[+:,\.\;\/\\-]bot
 [^a]fish
 ^voyager\/
@@ -140,7 +140,7 @@ lwp
 lwp\-request
 lwp\-tivial
 lwp\-trivial
-lycos[_+]
+lycos[_\+]
 mail.ru
 mediapartners\-google
 megite
@@ -202,7 +202,7 @@ ucsd
 ultraseek
 urlaliasbuilder
 urllib
-virus[_+]detector
+virus[_\+]detector
 voila
 w3c\-checklink
 webcollage

--- a/dspace/config/spiders/agents/iplists.com-non_engines
+++ b/dspace/config/spiders/agents/iplists.com-non_engines
@@ -2,14 +2,14 @@ ia_archiver
 http:\/\/www\.almaden\.ibm\.com\/cs\/crawler
 dtSearchSpider
 Mozilla\/4\.7 \(compatible; http:\/\/eidetica\.com\/spider\)
-e-SocietyRobot\(http:\/\/www\.yama\.info\.waseda\.ac\.jp\/~yamana\/es\/)
+e-SocietyRobot\(http:\/\/www\.yama\.info\.waseda\.ac\.jp\/~yamana\/es\/\)
 Mozilla\/4\.0 \(fantomBrowser\)
 Mozilla\/4\.0 \(stealthBrowser\)
 Mozilla\/4\.0 \(cloakBrowser\)
 Mozilla\/4\.0 \(fantomCrew Browser\)
 multiBlocker browser - IP blocker for Spam, Fraud \+ Snoop Protection
 multiBlocker browser
-Mozilla\/4\.0 \(compatible; MSIE 5\.0; Windows NT; Girafabot; girafabot at girafa dot com; http:\/\/www\.girafa\.com)
+Mozilla\/4\.0 \(compatible; MSIE 5\.0; Windows NT; Girafabot; girafabot at girafa dot com; http:\/\/www\.girafa\.com\)
 Googlebot\/2\.1 \(\+http:\/\/www\.googlebot\.com\/bot\.html\)
 Mozilla\/4\.0 \(compatible; MSIE 6\.0; Googlebot\/2\.1 \(\+http:\/\/www\.googlebot\.com\/bot\.html\); \.NET CLR 1\.0\.3705\)
 IncyWincy data gatherer\(webmaster\@loopimprovements\.com,http:\/\/www\.loopimprovements\.com\/robot\.html\)
@@ -26,7 +26,7 @@ flunky
 Microsoft URL Control - 5\.01\.4319
 NAMEPROTECT
 RPT-HTTPClient\/0\.3-3
-NPBot-1\/2\.0 \(http:\/\/www\.nameprotect\.com\/botinfo\.html)
+NPBot-1\/2\.0 \(http:\/\/www\.nameprotect\.com\/botinfo\.html\)
 aipbot\/1\.0 \(aipbot; http:\/\/www\.aipbot\.com; aipbot\@aipbot\.com\)
 NetMechanic V2\.0
 WebFilter Robot 1\.0
@@ -38,8 +38,8 @@ TurnitinBot\/1\.4 http:\/\/www\.turnitin\.com\/robot\/crawlerinfo\.html
 SlySearch
 WebZIP\/4\.0 \(http:\/\/www\.spidersoft\.com\)
 Teleport Pro\/1\.28
-\(Teradex Mapper; mapper\@teradex\.com; http:\/\/www\.teradex\.com)
-tivraSpider\/1\.0 \(crawler\@tivra\.com)
+\(Teradex Mapper; mapper\@teradex\.com; http:\/\/www\.teradex\.com\)
+tivraSpider\/1\.0 \(crawler\@tivra\.com\)
 UbiCrawler\/v0\.3beta \(http:\/\/ubi\.imc\.pi\.cnr\.it\/projects\/ubicrawler\/\)
 Webclipping\.com
 webrank

--- a/dspace/config/spiders/agents/iplists.com-non_engines
+++ b/dspace/config/spiders/agents/iplists.com-non_engines
@@ -2,17 +2,17 @@ ia_archiver
 http:\/\/www\.almaden\.ibm\.com\/cs\/crawler
 dtSearchSpider
 Mozilla\/4\.7 \(compatible; http:\/\/eidetica\.com\/spider\)
-e-SocietyRobot(http:\/\/www\.yama\.info\.waseda\.ac\.jp\/~yamana\/es\/)
+e-SocietyRobot\(http:\/\/www\.yama\.info\.waseda\.ac\.jp\/~yamana\/es\/)
 Mozilla\/4\.0 \(fantomBrowser\)
 Mozilla\/4\.0 \(stealthBrowser\)
 Mozilla\/4\.0 \(cloakBrowser\)
 Mozilla\/4\.0 \(fantomCrew Browser\)
 multiBlocker browser - IP blocker for Spam, Fraud \+ Snoop Protection
 multiBlocker browser
-Mozilla\/4\.0 (compatible; MSIE 5\.0; Windows NT; Girafabot; girafabot at girafa dot com; http:\/\/www\.girafa\.com)
+Mozilla\/4\.0 \(compatible; MSIE 5\.0; Windows NT; Girafabot; girafabot at girafa dot com; http:\/\/www\.girafa\.com)
 Googlebot\/2\.1 \(\+http:\/\/www\.googlebot\.com\/bot\.html\)
 Mozilla\/4\.0 \(compatible; MSIE 6\.0; Googlebot\/2\.1 \(\+http:\/\/www\.googlebot\.com\/bot\.html\); \.NET CLR 1\.0\.3705\)
-IncyWincy data gatherer\(webmaster@loopimprovements\.com,http:\/\/www\.loopimprovements\.com\/robot\.html\)
+IncyWincy data gatherer\(webmaster\@loopimprovements\.com,http:\/\/www\.loopimprovements\.com\/robot\.html\)
 Mozilla\/3\.0 \(compatible; Indy Library\)
 Sqworm\/2\.9\.72-BETA \(beta_release; 20010821-737; i686-pc-linux-gnu\)
 larbin
@@ -26,8 +26,8 @@ flunky
 Microsoft URL Control - 5\.01\.4319
 NAMEPROTECT
 RPT-HTTPClient\/0\.3-3
-NPBot-1\/2\.0 (http:\/\/www\.nameprotect\.com\/botinfo\.html)
-aipbot\/1\.0 \(aipbot; http:\/\/www\.aipbot\.com; aipbot@aipbot\.com\)
+NPBot-1\/2\.0 \(http:\/\/www\.nameprotect\.com\/botinfo\.html)
+aipbot\/1\.0 \(aipbot; http:\/\/www\.aipbot\.com; aipbot\@aipbot\.com\)
 NetMechanic V2\.0
 WebFilter Robot 1\.0
 PicaLoader 1\.0
@@ -38,8 +38,8 @@ TurnitinBot\/1\.4 http:\/\/www\.turnitin\.com\/robot\/crawlerinfo\.html
 SlySearch
 WebZIP\/4\.0 \(http:\/\/www\.spidersoft\.com\)
 Teleport Pro\/1\.28
-(Teradex Mapper; mapper@teradex\.com; http:\/\/www\.teradex\.com)
-tivraSpider\/1\.0 (crawler@tivra\.com)
+\(Teradex Mapper; mapper\@teradex\.com; http:\/\/www\.teradex\.com)
+tivraSpider\/1\.0 \(crawler\@tivra\.com)
 UbiCrawler\/v0\.3beta \(http:\/\/ubi\.imc\.pi\.cnr\.it\/projects\/ubicrawler\/\)
 Webclipping\.com
 webrank
@@ -49,6 +49,6 @@ AESOP_com_SpiderMan
 ozilla\/4\.7 \(compatible; Whizbang\)
 TECOMAC-Crawler\/0\.3
 X-Crawler
-cosmos\/0\.8\)_\(robot@xyleme\.com\)
+cosmos\/0\.8\)_\(robot\@xyleme\.com\)
 Mozilla\/4\.0\(compatible; Zealbot 1\.0\)
 Zeus 60359 Webster Pro V2\.9 Win32

--- a/dspace/config/spiders/agents/sedici_useragents
+++ b/dspace/config/spiders/agents/sedici_useragents
@@ -11,3 +11,112 @@ MauiBot
 ltx71
 Applebot
 BUbiNG
+BLEXBot
+archive.org_bot
+Twitterbot
+Blekkobot
+BDCbot
+TurnitinBot
+trendictionbot
+crawler4j
+SISTRIX Crawler
+ezooms\.bot
+wotbox
+linkdexbot\/2\.2
+Cliqzbot
+Vegi bot
+Goibot
+Barkrowler
+SEOkicks-Robot
+OpenLinkProfiler\.org\/bot
+SemrushBot
+Linguee Bot
+GarlikCrawler
+Go-http-client\/1\.1
+Apache-HttpClient\/4\.1\.3
+GrapeshotCrawler
+GrapeshotCrawler\/2\.0
+studylib download bot
+Altmetribot
+WBSearchBot\/1\.1
+Unpaywall
+Mozilla\/5\.0 \(compatible; OAI; \+http:\/\/www\.openaire\.eu\)
+jetmon\/[0-9]+\.[0-9]+
+^pyoai$
+^curl$
+Automattic Feed Fetcher [0-9]\.[0-9]
+Isidore\|Huma-Num Thumb Server
+GoogleImageProxy
+Moreover\/[0-9]+\.[0-9]+
+Bloglovin\/[0-9]+\.[0-9]+
+metha\/[0-9]+\.[0-9]+
+Net::OAI::Harvester
+Apache-HttpClient\/[0-9]+\.[0-9]+
+^Ruby$
+^Scoop\.it$
+SimplePie\/[0-9]+\.[0-9]+
+PDF Drive Crawler [0-9]\.[0-9]
+^Google-Test2$
+^BaiduSpider$
+^SEMrushBot$
+OAIHarvesterObj 31 University of Illinois Library
+um-IC\/[0-9]+\.[0-9]+
+aiohttp\/[0-9]+\.[0-9]+
+Faraday v[0-9]\.[0-9]
+IABot
+FeedlyBot\/[0-9]+\.[0-9]+
+lua-resty-http\/[0-9]+\.[0-9]+
+FeedBurner\/[0-9]+\.[0-9]+
+SimplePie\/[0-9]+\.[0-9]+
+LinkedInBot\/[0-9]+\.[0-9]+
+cortex\/[0-9]+\.[0-9]+
+TelegramBot
+mindUpBot
+Screaming Frog SEO Spider\/[0-9]+\.[0-9]+
+adreview\/[0-9]+\.[0-9]+
+ArcGIS Client Using WinInet
+TrendsmapResolver\/[0-9]+\.[0-9]+
+PocketParser\/[0-9]+\.[0-9]+
+Shareaholic\/[0-9]+\.[0-9]+
+metadataparser\/[0-9]+\.[0-9]+
+BootCaT\/[0-9]+\.[0-9]+
+BoardReader Blog Indexer
+YisouSpider
+JetBrains Omea Reader [0-9]+\.[0-9]+
+weborama-fetcher
+OutclicksBot
+NASA Astrophysics Data System indexer
+Photon\/[0-9]+\.[0-9]+
+okhttp\/[0-9]+\.[0-9]+
+RestSharp\/[0-9]+\.[0-9]+
+LinkAnalyser\/[0-9]+\.[0-9]+
+Ultraseek
+OSSProxy [0-9]+\.[0-9]+
+SabsimBot\/[0-9]+\.[0-9]+
+GoogleBot Indexing
+OAIPMH_Validator
+Gluten Free Crawler\/[0-9]+\.[0-9]+
+WebBot\/[0-9]+\.[0-9]+
+WebCrawler\/[0-9]+\.[0-9]+
+FlipboardProxy\/[0-9]+\.[0-9]+
+Faveeo\/[0-9]+\.[0-9]+
+Google-Site-Verification\/[0-9]+\.[0-9]+
+1science Resolver [0-9]+\.[0-9]+
+Mr.4x3 Powered
+Citoid
+inoreader\.com
+OAI-PERL\/[0-9]+\.[0-9]+
+Visor News Reader RSS\/[0-9]+\.[0-9]+
+tweetedtimes
+DuckDuckGo-Favicons-Bot\/[0-9]+\.[0-9]+
+omgili\/[0-9]+\.[0-9]+
+SMUrlExpander
+WalySoft \/[0-9]+\.x
+the Thinglink ImageBot
+eContext\/[0-9]+\.[0-9]+
+OER Commons Bot\/[0-9]+\.[0-9]+
+statista\.com
+GermCrawler
+Jaunt\/[0-9]+\.[0-9]+
+admantx-euaspb\/[0-9]+\.[0-9]+
+GetLinkInfo

--- a/dspace/config/spiders/agents/sedici_useragents
+++ b/dspace/config/spiders/agents/sedici_useragents
@@ -120,3 +120,10 @@ GermCrawler
 Jaunt\/[0-9]+\.[0-9]+
 admantx-euaspb\/[0-9]+\.[0-9]+
 GetLinkInfo
+UnChaos
+ReactorNetty\/[0-9]+\.[0-9]+
+SearchAtlas.com
+Nessus
+ZmEu
+netEstate NE Crawler
+GigablastOpenSource\/[0-9]+\.[0-9]+


### PR DESCRIPTION
Se realizó una revisión de las expresiones de User Agents mantenidas en el dir config/spiders/agents, a fin de que sean expresiones regulares válidas en Solr.

Además se completó la lista de User Agents con el listado existente en SEDICI.

Habria que revisar las expresiones corregidas y nuevas por si se detecta alguna expresión riesgosa o incorrecta. Además, si es posible, aplicar el marcado de bots sobre algun backup reciente del core 'statistics' del repositorio.