### PR TITLE
Agrego un límite en el valor máximo permitido para el parámetro rpp (resuts per page) en los browse y en la búsqueda.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -110,6 +110,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
     public static final String VARIANTS_STORE_SEPARATOR = "###";
 
+    public static final int MAX_RESULTS_ALLOWED = 100;
+
     @Autowired(required = true)
     protected ContentServiceFactory contentServiceFactory;
     @Autowired(required = true)
@@ -1676,6 +1678,10 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         if(discoveryQuery.getMaxResults() != -1)
         {
+            if (discoveryQuery.getMaxResults() > MAX_RESULTS_ALLOWED)
+            {
+                discoveryQuery.setMaxResults(MAX_RESULTS_ALLOWED);
+            }
             solrQuery.setRows(discoveryQuery.getMaxResults());
         }
 

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ConfigurableBrowse.java
@@ -766,7 +766,12 @@ public class ConfigurableBrowse extends AbstractDSpaceTransformer implements
             params.scope.setJumpToItem(RequestUtils.getIntParameter(request, BrowseParams.JUMPTO_ITEM));
             params.scope.setOrder(request.getParameter(BrowseParams.ORDER));
             updateOffset(request, params);
-            params.scope.setResultsPerPage(RequestUtils.getIntParameter(request, BrowseParams.RESULTS_PER_PAGE));
+            int rpp = RequestUtils.getIntParameter(request, BrowseParams.RESULTS_PER_PAGE);
+            int maxRpp = RESULTS_PER_PAGE_PROGRESSION[RESULTS_PER_PAGE_PROGRESSION.length-1];
+            if (rpp > maxRpp) {
+                rpp = maxRpp;
+            }
+            params.scope.setResultsPerPage(rpp);
             params.scope.setStartsWith(decodeFromURL(request.getParameter(BrowseParams.STARTS_WITH)));
             String filterValue = request.getParameter(BrowseParams.FILTER_VALUE[0]);
             if (filterValue == null)


### PR DESCRIPTION
Si este valor no se controla se pueden llegar a retornar todos los items en la búsqueda, lo que podría causar un DOS.
En solr agregué una variable MAX_RESULTS_ALLOWED para controlar la cantidad, mientras que en el browse controlo que el valor ingresado no se mas grande que el valor máximo mostrado en el select utilizado para setear el parámetro.