### PR TITLE
-#6842 Se agregó el tipo "Conjunto de datos"

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
@@ -74,6 +74,10 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='issued']/doc:element/doc:field[@name='value']">
 				<dc:date><xsl:value-of select="." /></dc:date>
 			</xsl:for-each>
+			<!-- dcterms.created -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='created']/doc:element/doc:field[@name='value']">
+				<dc:date><xsl:value-of select="." /></dc:date>
+			</xsl:for-each>
 			<!-- license.embargoEnd -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='others']/doc:field[@name='embargoEnd']">
 				<dc:date><xsl:value-of select="." /></dc:date>
@@ -86,6 +90,22 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='extent']/doc:element/doc:field[@name='value']">
 				<dc:format><xsl:value-of select="." /></dc:format>
 			</xsl:for-each>
+			<!-- dcterms.format -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='format']/doc:element/doc:field[@name='value']">
+				<dc:format><xsl:value-of select="." /></dc:format>
+			</xsl:for-each>
+			<!-- dcterms.medium -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='medium']/doc:element/doc:field[@name='value']">
+				<dc:format><xsl:value-of select="." /></dc:format>
+			</xsl:for-each>
+            <!--  dcterms.spatial -->
+            <xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='spatial']/doc:element/doc:field[@name='value']">
+                <dc:coverage><xsl:value-of select="." /></dc:coverage>
+            </xsl:for-each>
+            <!--  dcterms.temporal -->
+            <xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='temporal']/doc:element/doc:field[@name='value']">
+                <dc:coverage><xsl:value-of select="." /></dc:coverage>
+            </xsl:for-each>
 			<!-- dcterms.publisher -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
 				<dc:publisher><xsl:value-of select="." /></dc:publisher>

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -262,6 +262,9 @@
 				<xsl:when test="$theValue='Informe técnico'">
 					report
 				</xsl:when>
+				<xsl:when test="$theValue='Conjunto de datos'">
+					other
+				</xsl:when>
 				<!-- No se exporta 
 				<xsl:when test="$value='Objeto de Aprendizaje'">
 					report
@@ -395,6 +398,9 @@
 					report
 				</xsl:when>
 				 -->		
+                <xsl:when test="$theValue='Conjunto de datos'">
+                    conjunto de datos
+                </xsl:when>
 			</xsl:choose>
 		</xsl:variable>
 		<doc:element name="type">

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -445,7 +445,8 @@
 					<string>Trabajo de especializacion</string>
 					<string>Trabajo de especialización</string>
 					<string>Informe tecnico</string>
-					<string>Informe técnico</string>					
+					<string>Informe técnico</string>
+					<string>Conjunto de datos</string>
 				</list>
 			</Configuration>			
 		</CustomCondition>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -212,8 +212,19 @@
          <dc-element>issued</dc-element>
          <repeatable>false</repeatable>
          <label>Fecha de publicación</label>
+         <type-bind>!Conjunto de datos</type-bind>
          <input-type>date</input-type>
          <hint>Fecha de publicación, distribución pública o exposición. En caso de no haber difundido nunca su obra por ningún medio, indique la fecha de hoy como fecha de publicación. Puede omitir el día y mes si no lo sabe. </hint>
+       </field>
+       
+       <field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>created</dc-element>
+         <repeatable>false</repeatable>
+         <label>Fecha de creación</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>date</input-type>
+         <hint>Se puede indicar el año, año y mes, o año,mes y día. En caso de incertidumbre, indicar el año más próximo considerado y aclarar luego en las notas acerca de esta situación con c (circa), década o siglo. Ejemplo: c. 1910, Siglo XX.</hint>
        </field>
      
      	<!-- TODO: Este debe ofrecer una materia dentro del vocabulario FOS!!-->
@@ -260,6 +271,36 @@
          <label>Cobertura espacial</label>
          <input-type>twobox</input-type> <!-- TODO: select/lookup -->
          <hint>Información sobre la cobertura espacial/geográfica de la obra.</hint>
+       </field>
+       
+       <field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>temporal</dc-element>
+         <repeatable>true</repeatable>
+         <label>Alcance temporal</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>onebox</input-type>
+         <hint>Información sobre el período de tiempo específico del recurso. Si es posible, se debe indicar el comienzo y el fin del intervalo de tiempo, de la siguiente manera: "AñoComienzo-AñoFin" (por ejemplo, 1900-1978)</hint>
+       </field>
+
+       <field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>format</dc-element>
+         <repeatable>true</repeatable>
+         <label>Descripción fisica</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>textarea</input-type>
+         <hint>Descripción sobre la estructuración del conjunto de datos. Por ejemplo: "El conjunto de datos se compone de varios archivos .zip, donde cada uno contiene varias imágenes sobre..."</hint>
+       </field>
+
+       <field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>medium</dc-element>
+         <repeatable>true</repeatable>
+         <label>Materiales / Técnicas</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>textarea</input-type>
+         <hint>Materiales / Técnicas de recolección utilizadas para la generación del conjunto de datos.</hint>
        </field>
        
        <field>
@@ -482,10 +523,10 @@
          <dc-schema>dcterms</dc-schema>
          <dc-element>license</dc-element>
          <repeatable>false</repeatable>
-         <label>Licencia Creative Commons</label>
+         <label>Licencia</label>
 		<input-type>onebox</input-type>
-         <hint>Elija la licencia Creative Commons adecuada para el ítem.</hint>
-         <required>Debe asignarle una licencia Creative Commons al item.</required>
+         <hint>Elija la licencia adecuada para el ítem.</hint>
+         <required>Debe asignarle una licencia al item.</required>
        </field>
   	</page>
    </form>
@@ -586,8 +627,59 @@
          <dc-element>issued</dc-element>
          <repeatable>false</repeatable>
          <label>Fecha de publicación</label>
+         <type-bind>!Conjunto de datos</type-bind>
          <input-type>date</input-type>
          <hint>Fecha de publicación, distribución o exposición. En caso de no haber difundido nunca su obra por ningún medio, indique la fecha de hoy como fecha de publicación.</hint>
+       </field>
+       
+     	<field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>created</dc-element>
+         <repeatable>false</repeatable>
+         <label>Fecha de creación</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>date</input-type>
+         <hint>Se puede indicar el año, año y mes, o año,mes y día. En caso de incertidumbre, indicar el año más próximo considerado y aclarar luego en las notas acerca de esta situación con c (circa), década o siglo. Ejemplo: c. 1910, Siglo XX.</hint>
+       </field>
+       
+       <field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>spatial</dc-element>
+         <repeatable>true</repeatable>
+         <label>Cobertura espacial</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>twobox</input-type>
+         <hint>Información sobre la cobertura espacial/geográfica del recurso.</hint>
+       </field>
+
+       <field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>temporal</dc-element>
+         <repeatable>true</repeatable>
+         <label>Alcance temporal</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>onebox</input-type>
+         <hint>Información sobre el período de tiempo específico del recurso. Si es posible, se debe indicar el comienzo y el fin del intervalo de tiempo, de la siguiente manera: "AñoComienzo-AñoFin" (por ejemplo, 1900-1978)</hint>
+       </field>
+
+       <field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>medium</dc-element>
+         <repeatable>true</repeatable>
+         <label>Materiales / Técnicas</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>textarea</input-type>
+         <hint>Materiales / Técnicas de recolección utilizadas para la generación del conjunto de datos.</hint>
+       </field>
+
+       <field>
+         <dc-schema>dcterms</dc-schema>
+         <dc-element>format</dc-element>
+         <repeatable>true</repeatable>
+         <label>Descripción fisica</label>
+         <type-bind>Conjunto de datos</type-bind>
+         <input-type>onebox</input-type>
+         <hint>Descripción sobre la estructuración del conjunto de datos. Por ejemplo: "El conjunto de datos se compone de varios archivos .zip, donde cada uno contiene varias imágenes sobre..."</hint>
        </field>
      
      	<!-- TODO: Este debe ofrecer un multi-vocabulario controlado decs+ACM -->
@@ -879,6 +971,18 @@
 			<displayed-value>Attribution-NonCommercial-NoDerivs  2.5 (BY-NC-ND 2.5 Argentina)</displayed-value>
 			<stored-value>http://creativecommons.org/licenses/by-nc-nd/2.5/ar/</stored-value>
 		</pair>
+		<pair>
+			<displayed-value>Open Data Commons Open Database License (ODbL) v1.0</displayed-value>
+			<stored-value>https://opendatacommons.org/licenses/odbl/1-0/</stored-value>
+		</pair>
+		<pair>
+			<displayed-value>Open Data Commons Attribution License (ODC-By) v1.0</displayed-value>
+			<stored-value>https://opendatacommons.org/licenses/by/1-0/</stored-value>
+		</pair>
+		<pair>
+			<displayed-value>Open Data Commons Public Domain Dedication and License (PDDL) v1.0</displayed-value>
+			<stored-value>https://opendatacommons.org/licenses/pddl/1-0/</stored-value>
+		</pair>
 	</value-pairs>
     
     <value-pairs value-pairs-name="cic_areas" dc-term="dcterms_subject_area">
@@ -1053,6 +1157,10 @@
 		<displayed-value>Video</displayed-value>
 		<stored-value>cic:types/imagenEnMovimiento/video</stored-value>
 	</pair>
+	<pair>
+        <displayed-value>Conjunto de datos</displayed-value>
+        <stored-value>cic:types/conjuntoDeDatos/conjuntoDeDatos</stored-value>
+    </pair>
 </value-pairs>
     
  </form-value-pairs>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2261,6 +2261,7 @@
 	<message key="xmlui.dri2xhtml.structural.link_original_license">Original License</message>
 	<!-- CIC-Digital -->
 	<message key="xmlui.dri2xhtml.structural.cc-item-view-text">This work is published under license Creative Commons </message>
+	<message key="xmlui.dri2xhtml.structural.opendatacommonslicense-item-view-text">This work is published under license Open Data Commons </message>
 	<message key="xmlui.dri2xhtml.structural.cc-by-4.0">Attribution 4.0 International (BY 4.0)</message>
 	<message key="xmlui.dri2xhtml.structural.cc-by-sa-4.0">Attribution-ShareAlike 4.0 International (BY-SA 4.0)</message>
 	<message key="xmlui.dri2xhtml.structural.cc-by-nd-4.0">Attribution-NoDerivatives  4.0 International (BY-ND 4.0)</message>
@@ -2319,12 +2320,16 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_abstract">Abstract</message>
 <!-- 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_abstract_trabajoRealizado">Developed work</message> -->
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_issued">Date issued</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_created">Date created</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_materia">Subject</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_area">Tematic area</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject">Keyword</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_spatial">Spatial coverage</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_temporal">Temporal coverage</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_language">Lenguage</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_extent">Extension</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_format">Physical Description</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_medium">Materials / Techniques</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_publisher">Publisher</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_rights_embargoPeriod">Embargo period</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_identifier_url">Electronic localization</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -2168,6 +2168,7 @@ Para más infomación, visite
 <message key="xmlui.dri2xhtml.structural.link_original_license">Licencia original</message>
 <!-- CIC-Digital -->
 <message key="xmlui.dri2xhtml.structural.cc-item-view-text">Esta obra se publica con la licencia Creative Commons </message>
+<message key="xmlui.dri2xhtml.structural.opendatacommonslicense-item-view-text">Esta obra se publica con la licencia Open Data Commons </message>
 
 <message key="mxlui.dri2xhtml.structural.cc-phone">Telefono</message>
 <message key="mxlui.dri2xhtml.structural.cc-street">Calle</message>
@@ -2209,12 +2210,16 @@ Puede reemplazar la plantilla que gestiona el caso general dri2xhtml para mejora
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_abstract">Resumen</message>
 <!-- <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_abstract_trabajoRealizado">Labor desarrollada</message> -->
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_issued">Fecha de publicación</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_created">Fecha de creación</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_materia">Materia</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_area">Área temática</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject">Palabra clave</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_spatial">Cobertura espacial</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_temporal">Alcance temporal</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_language">Lenguaje</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_extent">Extensión</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_format">Descripción Física</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_medium">Materiales / Técnicas</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_publisher">Editorial</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_rights_embargoPeriod">Periodo de embargo</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_identifier_url">Localización electrónica</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
@@ -2692,6 +2692,7 @@
     <message key="xmlui.XMLWorkflow.autoarchive.CIC-ADMIN_review.changecollection">Seleção de coleção CIC-Digital</message>
     <message key="xmlui.statistics.display.chartist.country.others">Outros países</message>
     <message key="xmlui.dri2xhtml.structural.cc-item-view-text">Este trabalho é publicado sob a licença Creative Commons</message>
+    <message key="xmlui.dri2xhtml.structural.opendatacommonslicense-item-view-text">Este trabalho é publicado sob a licença Open Data Commons</message>
     <message key="mxlui.dri2xhtml.structural.cc-phone">Telefone</message>
     <message key="mxlui.dri2xhtml.structural.cc-street">Rua</message>
     <message key="mxlui.dri2xhtml.structural.cc-between">entre</message>
@@ -2707,12 +2708,16 @@
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_abstract">Resumo</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_abstract_trabajoRealizado">Trabalho desenvolvido -></message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_issued">Data de publicação</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_created">Data de criação</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_materia">Matéria</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_area">Área temática</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject">Palavra chave</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_spatial">Cobertura Espacial</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_temporal">Alcance temporal</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_language">Idioma</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_extent">Extensão</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_format">Descrição física</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_medium">Materiais / Técnicas</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_publisher">Editorial</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_rights_embargoPeriod">Período de embargo</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_identifier_url">Localização Eletrônica</message>

--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/discovery.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/discovery.xsl
@@ -273,6 +273,9 @@
 	                        <xsl:when test="dri:list[@n=(concat($handle, ':dcterms.issued')) and descendant::text()]">
 	                            <xsl:value-of select="substring(dri:list[@n=(concat($handle, ':dcterms.issued'))]/dri:item[position()=1]/text(), 1, 4)" />
 	                        </xsl:when>
+	                        <xsl:when test="dri:list[@n=(concat($handle, ':dcterms.created')) and descendant::text()]">
+	                            <xsl:value-of select="substring(dri:list[@n=(concat($handle, ':dcterms.created'))]/dri:item[position()=1]/text(), 1, 4)" />
+	                        </xsl:when>
 	                        <xsl:otherwise>
 <!-- 	                        		Sin título -->
 	                            <i18n:text>xmlui.dri2xhtml.METS-1.0.no-date</i18n:text>

--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -305,10 +305,10 @@
 				</div>
 				<div class="row col-md-2 col-md-push-10" id="yearbox-container">
 					<div class="hidden-xs hidden-sm year-box">
-		    			<label id="año"><i18n:text>xmlui.ArtifactBrowser.ItemViewer.year</i18n:text><h3><xsl:value-of select="substring(//mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@mdschema='dcterms'][@element='issued']/text(), 1, 4)"></xsl:value-of></h3></label>
+		    			<label id="año"><i18n:text>xmlui.ArtifactBrowser.ItemViewer.year</i18n:text><h3><xsl:value-of select="substring(//mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@mdschema='dcterms'][@element='issued' or @element='created']/text(), 1, 4)"></xsl:value-of></h3></label>
 		    		</div>
 		    		<div class="col-md-1 col-md-push-3 visible-xs visible-sm year-box" id="year-box-small">
-		    			<label id="año"><i18n:text>xmlui.ArtifactBrowser.ItemViewer.year</i18n:text>: <xsl:value-of select="substring(//mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@mdschema='dcterms'][@element='issued']/text(), 1, 4)"></xsl:value-of></label>
+		    			<label id="año"><i18n:text>xmlui.ArtifactBrowser.ItemViewer.year</i18n:text>: <xsl:value-of select="substring(//mets:dmdSec/mets:mdWrap/mets:xmlData/dim:dim/dim:field[@mdschema='dcterms'][@element='issued' or @element='created']/text(), 1, 4)"></xsl:value-of></label>
 		    		</div>					
 				</div>
 	    		
@@ -397,6 +397,7 @@
         	<xsl:variable name="cc-uri">
 				<xsl:value-of select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim/dim:field[@mdschema='dcterms' and @element='license']/@authority"/>
 			</xsl:variable>
+		   <xsl:if test="contains($cc-uri, 'creativecommons.org')">
         	<div class="col-md-1">
 		        <!-- Generate the Creative Commons license information from the file section (DSpace deposit license hidden by default)-->
 				<!-- <xsl:apply-templates select="./mets:fileSec/mets:fileGrp[@USE='CC-LICENSE']"/> -->
@@ -408,6 +409,17 @@
 				<i18n:text>xmlui.dri2xhtml.structural.cc-item-view-text</i18n:text>
 				<i18n:text><xsl:value-of select="concat('xmlui.dri2xhtml.structural.cc-',xmlui:stripDash(xmlui:replaceAll(substring-after($cc-uri, 'http://creativecommons.org/licenses/'), '/', '-')))"/></i18n:text>
 			</div>
+		   </xsl:if>
+		   <xsl:if test="contains($cc-uri, 'opendatacommons.org')">
+            <xsl:variable name="license-text" select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim/dim:field[@mdschema='dcterms' and @element='license']/text()"/>
+            <div class="col-md-6">
+                <i18n:text>xmlui.dri2xhtml.structural.opendatacommonslicense-item-view-text</i18n:text>
+                <a>
+                    <xsl:attribute name="href"><xsl:value-of select="$cc-uri"/></xsl:attribute>
+                    <xsl:value-of select="$license-text"/>
+                </a>
+            </div>
+		   </xsl:if>
 	     </div>
 	     
 	     <!-- Show full link -->
@@ -669,11 +681,23 @@
 						<xsl:with-param name="container" select="'li'" />
 					</xsl:call-template>
 					<xsl:call-template name="render-metadata">
+						<xsl:with-param name="field" select="'dcterms.temporal'" />
+						<xsl:with-param name="container" select="'li'" />
+					</xsl:call-template>
+					<xsl:call-template name="render-metadata">
 						<xsl:with-param name="field" select="'dcterms.language'" />
 						<xsl:with-param name="container" select="'li'" />
 					</xsl:call-template>
 					<xsl:call-template name="render-metadata">
 						<xsl:with-param name="field" select="'dcterms.extent'" />
+						<xsl:with-param name="container" select="'li'" />
+					</xsl:call-template>
+					<xsl:call-template name="render-metadata">
+						<xsl:with-param name="field" select="'dcterms.format'" />
+						<xsl:with-param name="container" select="'li'" />
+					</xsl:call-template>
+					<xsl:call-template name="render-metadata">
+						<xsl:with-param name="field" select="'dcterms.medium'" />
 						<xsl:with-param name="container" select="'li'" />
 					</xsl:call-template>
 				</ul>
@@ -700,6 +724,11 @@
 						</xsl:call-template>
 						<xsl:call-template name="render-metadata">
 							<xsl:with-param name="field" select="'dcterms.issued'" />
+							<xsl:with-param name="container" select="'li'" />
+							<xsl:with-param name="isDate">True</xsl:with-param>
+						</xsl:call-template>
+						<xsl:call-template name="render-metadata">
+							<xsl:with-param name="field" select="'dcterms.created'" />
 							<xsl:with-param name="container" select="'li'" />
 							<xsl:with-param name="isDate">True</xsl:with-param>
 						</xsl:call-template>


### PR DESCRIPTION
Así tambien se configuraron las vistas de los items, los mapeos OAI, y se agregué las licencias Open Data Commons para su uso.

También se agregaron al formulario de carga los siguientes metadatos (tanto para autoarchivo como para el traditional):
- dcterms.created
- dcterms.spatial
- dcterms.temporal
- dcterms.format
- dcterms.medium