### PR TITLE
-#6860 Agrego metadato para vocabulario FORD en los conjuntos de datos

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
@@ -54,8 +54,12 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='contributor']/doc:element[@name='director']/doc:element/doc:field[@name='value']">
 				<dc:contributor><xsl:value-of select="." /></dc:contributor>
 			</xsl:for-each>
-			<!-- dcterms.subject.* -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='subject']/doc:element/doc:element/doc:field[@name='value']">
+			<!-- dcterms.subject.* excepto subject.ford -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='subject']/doc:element[@name!='ford']/doc:element/doc:field[@name='value']">
+				<dc:subject><xsl:value-of select="." /></dc:subject>
+			</xsl:for-each>
+			<!--dcterms.subject.ford imprimo solo la uri de autoridad -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='subject']/doc:element[@name='ford']/doc:element/doc:field[@name='authority']">
 				<dc:subject><xsl:value-of select="." /></dc:subject>
 			</xsl:for-each>
 			<!-- dcterms.abstract -->

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -238,6 +238,18 @@
          <hint>Materia (en sentido amplio) a que se refiere el item (ejemplo: Física).</hint>
          <required>Debe indicar al menos una materia relacionada al item.</required>
        </field>
+
+       <!-- Clasificación FORD por áreas de investigación y desarrollo -->
+       <field>
+	    <dc-schema>dcterms</dc-schema>
+	    <dc-element>subject</dc-element>
+	    <dc-qualifier>ford</dc-qualifier>
+	    <repeatable>true</repeatable>
+	    <label>Clasificación FORD (*)</label>
+	    <type-bind>Conjunto de datos</type-bind>
+	    <input-type>onebox</input-type>
+	    <hint>Clasificación del documento por áreas de investigación y desarrollo (FORD por su sigla en inglés)</hint>
+       </field>
      	
      	<!-- TODO: Este debe ofrecer una materia dentro del vocabulario Getty : http://vocab.getty.edu/!!-->
      	<field>

--- a/dspace/config/local_custom.cfg
+++ b/dspace/config/local_custom.cfg
@@ -204,7 +204,8 @@ plugin.named.org.dspace.content.authority.ChoiceAuthority = \
  org.dspace.content.authority.EmptyAuthority = EmptyAuthority, \
  ar.gob.gba.cic.digital.Author_CICBA_Authority = Author_CICBA_Authority, \
  ar.gob.gba.cic.digital.Institution_CICBA_Authority = Institution_CICBA_Authority, \
- ar.gob.gba.cic.digital.General_CICBA_Authority = General_CICBA_Authority
+ ar.gob.gba.cic.digital.General_CICBA_Authority = General_CICBA_Authority, \
+ ar.gob.gba.cic.digital.FORD_Subject_CICBA_Authority = FORD_Subject_CICBA_Authority
 ##URL authority example : raw and emptyAuthority
 ##---dcterms.isPartOf.item---
 choices.plugin.dcterms.isPartOf.item = EmptyAuthority
@@ -317,6 +318,14 @@ choices.closed.dcterms.subject = false
 choices.minLength.dcterms.subject = 4
 choices.typeProperty.dcterms.subject = cic:Term
 choices.labelProperty.dcterms.subject = dc:title
+#---dcterms.subject.ford---
+choices.plugin.dcterms.subject.ford = FORD_Subject_CICBA_Authority
+choices.presentation.dcterms.subject.ford = suggest
+authority.controlled.dcterms.subject.ford = true
+choices.closed.dcterms.subject.ford = true
+choices.externalKeyProperty.dcterms.subject.ford = owl:sameAs
+choices.typeProperty.dcterms.subject.ford = cic:FORD
+choices.labelProperty.dcterms.subject.ford = rdfs:label
 #---dcterms.identifier.url--- (todavía queda pendiente el ticket #3689)
 #choices.plugin.dcterms.identifier.url = EmptyAuthority
 #choices.presentation.dcterms.identifier.url= raw

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -118,7 +118,14 @@
 		<qualifier>materia</qualifier>
 		<scope_note>Materia (en sentido amplio) a que se refiere el item (ejemplo: Física).</scope_note>
 	</dc-type>
-	
+
+	<dc-type>
+		<schema>dcterms</schema>
+		<element>subject</element>
+		<qualifier>ford</qualifier>
+		<scope_note>Clasificación FORD por áreas de investigación y desarrollo del documento</scope_note>
+	</dc-type>
+
 	<dc-type>
 		<schema>dcterms</schema>
 		<element>subject</element>

--- a/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
+++ b/dspace/modules/additions/src/main/java/ar/edu/unlp/sedici/dspace/authority/SPARQLAuthorityProvider.java
@@ -27,6 +27,7 @@ public abstract class SPARQLAuthorityProvider implements ChoiceAuthority {
 	protected static final String NS_DC = "http://purl.org/dc/terms/";
 	protected static final String NS_SIOC = "http://rdfs.org/sioc/ns#";
 	protected static final String NS_CERIF = "http://spi-fm.uca.es/neologism/cerif/1.3#";
+	protected static final String NS_OWL= "http://www.w3.org/2002/07/owl#";
 
 	private QuerySolutionMap globalParameters;
 

--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/FORD_Subject_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/FORD_Subject_CICBA_Authority.java
@@ -1,0 +1,33 @@
+package ar.gob.gba.cic.digital;
+
+import org.dspace.content.authority.Choice;
+
+import com.hp.hpl.jena.query.ParameterizedSparqlString;
+import com.hp.hpl.jena.query.QuerySolution;
+
+public class FORD_Subject_CICBA_Authority extends General_CICBA_Authority {
+
+	@Override
+	protected String getSelectQueryFields(boolean idSearch) {
+		return " DISTINCT ?label ?externalKey";
+	}
+
+	@Override
+	protected Choice extractChoice(QuerySolution solution) {
+		String key = "";
+		if (solution.contains("externalKey")) {
+			key = solution.getLiteral("externalKey").getString();
+		} else {
+			key = solution.getResource("concept").getURI();
+		}
+		String value = solution.getLiteral("label").getString();
+		String label = value;
+		return new Choice(key, value, label);
+	}
+
+	protected void getIdSearchFilterQuery(ParameterizedSparqlString pqs, String filter) {
+		pqs.append("FILTER(?externalKey = ?key) \n");
+		pqs.setLiteral("key", filter);
+	}
+
+}

--- a/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/General_CICBA_Authority.java
+++ b/dspace/modules/additions/src/main/java/ar/gob/gba/cic/digital/General_CICBA_Authority.java
@@ -21,6 +21,7 @@ public class General_CICBA_Authority extends SPARQLAuthorityProvider {
     protected final String CHOICES_PARENTPROPERTY_PREFIX = "choices.parentProperty.";
     protected final String CHOICES_TYPEPROPERTY_PREFIX = "choices.typeProperty.";
     protected final String CHOICES_LABELPROPERTY_PREFIX = "choices.labelProperty.";
+    protected final String CHOICES_EXTERNALKEY_PREFIX = "choices.externalKeyProperty.";
 
 	protected ParameterizedSparqlString getSparqlSearch(
 			String field, String filter, String locale,boolean idSearch) {
@@ -32,6 +33,7 @@ public class General_CICBA_Authority extends SPARQLAuthorityProvider {
 		String parent= configurationService.getProperty(CHOICES_PARENT_PREFIX+metadataField,null);
 		String parentProperty= configurationService.getProperty(CHOICES_PARENTPROPERTY_PREFIX+metadataField,"skos:broader");
 		boolean onlyLeafs= configurationService.getBooleanProperty(CHOICES_ONLYLEAFS_PREFIX+metadataField,false);
+		String externalKey= configurationService.getProperty(CHOICES_EXTERNALKEY_PREFIX + metadataField, null);
 
 		ParameterizedSparqlString pqs = new ParameterizedSparqlString();
 
@@ -39,11 +41,16 @@ public class General_CICBA_Authority extends SPARQLAuthorityProvider {
 		pqs.setNsPrefix("dc", NS_DC);
 		pqs.setNsPrefix("cic", NS_CIC);
 		pqs.setNsPrefix("skos", NS_SKOS);
+		pqs.setNsPrefix("owl", NS_OWL);
+		pqs.setNsPrefix("rdfs", NS_RDFS);
 
 		pqs.setCommandText("SELECT "+ this.getSelectQueryFields(idSearch) + "\n");
 		pqs.append("WHERE {\n");
 		pqs.append("?concept a "+ typeProperty + " .\n");
 		pqs.append("?concept "+ labelProperty +" ?label .\n");
+		if (externalKey != null) {
+			pqs.append("?concept "+ externalKey +" ?externalKey .\n");
+		}
 
 		if (parent != null) {
 		   //Si el parent es vacio se buscan nodos raiz, es decir, sin padre

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2324,6 +2324,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_materia">Subject</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_area">Tematic area</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject">Keyword</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_ford">FORD classification</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_spatial">Spatial coverage</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_temporal">Temporal coverage</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_language">Lenguage</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_es.xml
@@ -2214,6 +2214,7 @@ Puede reemplazar la plantilla que gestiona el caso general dri2xhtml para mejora
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_materia">Materia</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_area">Área temática</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject">Palabra clave</message>
+<message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_ford">Clasificación FORD</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_spatial">Cobertura espacial</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_temporal">Alcance temporal</message>
 <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_language">Lenguaje</message>

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages_pt_BR.xml
@@ -2712,6 +2712,7 @@
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_materia">Matéria</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_area">Área temática</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject">Palavra chave</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_subject_ford">Classificação FORD</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_spatial">Cobertura Espacial</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_temporal">Alcance temporal</message>
     <message key="xmlui.dri2xhtml.METS-1.0.item-dcterms_language">Idioma</message>

--- a/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui/src/main/webapp/themes/cicba/lib/xsl/aspect/artifactbrowser/item-view.xsl
@@ -677,6 +677,11 @@
 						<xsl:with-param name="local_browse_type" select="'subject'"/>
 					</xsl:call-template>
 					<xsl:call-template name="render-metadata">
+						<xsl:with-param name="field" select="'dcterms.subject.ford'" />
+						<xsl:with-param name="container" select="'li'" />
+						<xsl:with-param name="is_linked_authority" select="'true'" />
+					</xsl:call-template>
+					<xsl:call-template name="render-metadata">
 						<xsl:with-param name="field" select="'dcterms.spatial'" />
 						<xsl:with-param name="container" select="'li'" />
 					</xsl:call-template>


### PR DESCRIPTION
- Agrego el metadato dcterms.subject.ford que contendrá la tipología ford de materias
- Agrego el metadato al input-forms, solo para los conjuntos de datos
- Agrego el metadato en la vista de un item con las traducciones correspondientes
- Lo agrego al registry de metadatos, en el archivo registries/local-types.xml
- El metadato es controlado por autoridad, para eso creo una nueva clase FORD_Subject_CICBA_Authority, hija de General_CICBA_Authority, que contiene configuraciones especiales para la query a drupal de esta tipología
- Modifico el provider de drupal, SPARQLAuthorityProvider y  General_CICBA_Authority, para incluir las configuracion de una externalKey, necesaria para FORD
- Agrego mapeos a OAI