### PR TITLE
Ticket#6862 Acomodo mapeo a snrd de varios metadatos

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
@@ -111,7 +111,8 @@
 				<dc:date><xsl:value-of select="." /></dc:date>
 			</xsl:for-each>
 			<!-- license.embargoEnd -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='snrd']/doc:field[@name='rights']/doc:field[@name='embargoEnd']/doc:element/doc:field[@name='value']">
+			<!-- Si tiene embargo se debe mostrar la fecha de fin -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='snrd']/doc:element[@name='rights']/doc:element[@name='embargoEndDate']/doc:element/doc:field[@name='value']">
 				<dc:date><xsl:value-of select="." /></dc:date>
 			</xsl:for-each>
 			<!-- mimetype -->
@@ -150,15 +151,11 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='other']/doc:element/doc:field[@name='value']">
 				<dc:relation><xsl:value-of select="." /></dc:relation>
 			</xsl:for-each>
-<!-- 			 dc.rights.* -->
-<!-- 			<xsl:for-each select="doc:metadata/doc:element[@name='others']/doc:field[@name='accessRights']"> -->
-<!-- 				<dc:rights><xsl:value-of select="." /></dc:rights> -->
-<!-- 			</xsl:for-each> -->
 			<!-- dc.rights -->
-			<!-- Si es contexto snrd mostrar dc:rights dependiendo de si tiene o no embargo -->
-<!-- 			<xsl:for-each select="doc:metadata/doc:element[@name='snrd']/doc:element[@name='rights']/doc:element[@name='accessRights']/doc:element/doc:field[@name='value']"> -->
-			<dc:rights>info:eu-repo/semantics/openAccess</dc:rights>
-<!-- 			</xsl:for-each> -->
+			<!-- En el contexto snrd mostrar dc:rights dependiendo de si tiene o no embargo -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='snrd']/doc:element[@name='rights']/doc:element[@name='accessRights']/doc:element/doc:field[@name='value']">
+				<dc:rights><xsl:value-of select="." /></dc:rights>
+			</xsl:for-each>
 			<!-- dcterms.license -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='license']/doc:element/doc:field[@name='authority']">
 				<dc:rights><xsl:value-of select="." /></dc:rights>

--- a/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
@@ -23,6 +23,18 @@
 			xmlns:dc="http://purl.org/dc/elements/1.1/" 
 			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 			xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+			<!-- dc.identifier.uri -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
+				<dc:identifier><xsl:value-of select="." /></dc:identifier>
+			</xsl:for-each>
+			<!-- dcterms.identifier.url -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='url']/doc:element/doc:field[@name='value']">
+				<dc:identifier><xsl:value-of select="." /></dc:identifier>
+			</xsl:for-each>
+			<!-- dcterms.identifier.isbn -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='isbn']/doc:element/doc:field[@name='value']">
+				<dc:identifier><xsl:value-of select="." /></dc:identifier>
+			</xsl:for-each>
 			<!-- dc.type -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='type']/doc:element[@name='driver']/doc:field[@name='value']">
 				<dc:type><xsl:value-of select="concat('info:eu-repo/semantics/',.)" /></dc:type>
@@ -46,12 +58,24 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='title']/doc:element/doc:field[@name='value']">
 				<dc:title><xsl:value-of select="." /></dc:title>
 			</xsl:for-each>
-			<!-- dcterms.creator.* -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='creator']/doc:element/doc:element/doc:field[@name='value']">
+			<!-- dcterms.creator.author -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='creator']/doc:element[@name='author']/doc:element/doc:field[@name='value']">
 				<dc:creator><xsl:value-of select="." /></dc:creator>
 			</xsl:for-each>
-			<!-- dc.contributor.director-->
+			<!-- dcterms.creator.corporate -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='creator']/doc:element[@name='corporate']/doc:element/doc:field[@name='value']">
+				<dc:creator><xsl:value-of select="." /></dc:creator>
+			</xsl:for-each>
+			<!-- dcterms.contributor.director-->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='contributor']/doc:element[@name='director']/doc:element/doc:field[@name='value']">
+				<dc:contributor><xsl:value-of select="." /></dc:contributor>
+			</xsl:for-each>
+			<!-- dcterms.creator.* not author and not corporate -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='creator']/doc:element[@name!='author' and @name!='corporate']/doc:element/doc:field[@name='value']">
+				<dc:contributor><xsl:value-of select="." /></dc:contributor>
+			</xsl:for-each>
+			<!-- dcterms.contributor -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='contributor']/doc:element/doc:field[@name='value']">
 				<dc:contributor><xsl:value-of select="." /></dc:contributor>
 			</xsl:for-each>
 			<!-- dcterms.subject.* excepto subject.ford -->
@@ -60,6 +84,10 @@
 			</xsl:for-each>
 			<!--dcterms.subject.ford imprimo solo la uri de autoridad -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='subject']/doc:element[@name='ford']/doc:element/doc:field[@name='authority']">
+				<dc:subject><xsl:value-of select="." /></dc:subject>
+			</xsl:for-each>
+			<!-- dcterms.subject -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='subject']/doc:element/doc:field[@name='value']">
 				<dc:subject><xsl:value-of select="." /></dc:subject>
 			</xsl:for-each>
 			<!-- dcterms.abstract -->
@@ -83,7 +111,7 @@
 				<dc:date><xsl:value-of select="." /></dc:date>
 			</xsl:for-each>
 			<!-- license.embargoEnd -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='others']/doc:field[@name='embargoEnd']">
+			<xsl:for-each select="doc:metadata/doc:element[@name='snrd']/doc:field[@name='rights']/doc:field[@name='embargoEnd']/doc:element/doc:field[@name='value']">
 				<dc:date><xsl:value-of select="." /></dc:date>
 			</xsl:for-each>
 			<!-- mimetype -->
@@ -114,24 +142,12 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='publisher']/doc:element/doc:field[@name='value']">
 				<dc:publisher><xsl:value-of select="." /></dc:publisher>
 			</xsl:for-each>			
-			<!-- dc.identifier.uri -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
-				<dc:identifier><xsl:value-of select="." /></dc:identifier>
-			</xsl:for-each>
-			<!-- dcterms.identifier.url -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='url']/doc:element/doc:field[@name='value']">
-				<dc:identifier><xsl:value-of select="." /></dc:identifier>
-			</xsl:for-each>
 			<!-- dcterms.language -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='language']/doc:element/doc:field[@name='value']">
 				<dc:language><xsl:value-of select="." /></dc:language>
 			</xsl:for-each>
-			<!-- dcterms.identifier.isbn -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='isbn']/doc:field[@name='value']">
-				<dc:relation><xsl:value-of select="." /></dc:relation>
-			</xsl:for-each>
 			<!-- dcterms.identifier.other -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='other']/doc:field[@name='value']">
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='other']/doc:element/doc:field[@name='value']">
 				<dc:relation><xsl:value-of select="." /></dc:relation>
 			</xsl:for-each>
 <!-- 			 dc.rights.* -->
@@ -139,10 +155,12 @@
 <!-- 				<dc:rights><xsl:value-of select="." /></dc:rights> -->
 <!-- 			</xsl:for-each> -->
 			<!-- dc.rights -->
-			<!-- Como solo mostramos items OPEN, esto se harcodea -->
+			<!-- Si es contexto snrd mostrar dc:rights dependiendo de si tiene o no embargo -->
+<!-- 			<xsl:for-each select="doc:metadata/doc:element[@name='snrd']/doc:element[@name='rights']/doc:element[@name='accessRights']/doc:element/doc:field[@name='value']"> -->
 			<dc:rights>info:eu-repo/semantics/openAccess</dc:rights>
+<!-- 			</xsl:for-each> -->
 			<!-- dcterms.license -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='license']/doc:element/doc:field[@name='value']">
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='license']/doc:element/doc:field[@name='authority']">
 				<dc:rights><xsl:value-of select="." /></dc:rights>
 			</xsl:for-each>
 		</oai_dc:dc>

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -98,12 +98,12 @@
 		<xsl:choose>
 			<xsl:when test="contains(.,':')">
 				<xsl:variable name="esquema" select="substring-before(.,':')"/>
-				<xsl:variable name="identificador" select="substring-after(.,':')"/>
+				<xsl:variable name="identificador" select="normalize-space(substring-after(.,':'))"/>
 				<xsl:value-of select="concat($prefix,$esquema,'/',$identificador)"/>
 			</xsl:when>
 			<xsl:otherwise>
 				<xsl:variable name="esquema" select="substring-before(.,' ')"/>
-				<xsl:variable name="identificador" select="substring-after(.,' ')"/>
+				<xsl:variable name="identificador" select="normalize-space(substring-after(.,' '))"/>
 				<xsl:value-of select="concat($prefix,$esquema,'/',$identificador)"/>
 			</xsl:otherwise>
 		</xsl:choose>
@@ -504,10 +504,11 @@
 	<!-- Date format -->
 	<xsl:template name="formatdate">
 		<xsl:param name="datestr" />
-		<xsl:variable name="sub">
+                <xsl:param name="prefix" />
+                <xsl:variable name="sub">
 			<xsl:value-of select="substring($datestr,1,10)" />
 		</xsl:variable>
-		<xsl:value-of select="$sub" />
+		<xsl:value-of select="concat($prefix,$sub)" />
 	</xsl:template>
 
 	<xsl:template name="accessRightsAndEmbargo">

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -55,7 +55,7 @@
 	<!--  Formatting dcterms.created -->
 	<!-- Sólo procesamos y mostramos el dcterms.created si es que NO EXISTE el dcterms.issued. -->
 	<xsl:template match="/doc:metadata/doc:element[@name='dcterms']/doc:element[@name='created']">
-		<xsl:if test="not(../../../doc:element[@name='dcterms']/doc:element[@name='issued'])">
+		<xsl:if test="not(../../doc:element[@name='dcterms']/doc:element[@name='issued'])">
 			<doc:element name="created">
 				<doc:element name="es">
 					<doc:field name="value">

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -190,21 +190,40 @@
 
 
     <Filters>
-    
-    	<Filter id="snrdFilter">
-    		<Definition>
-    			<And>
-    				<LeftCondition>
-						<Custom ref="snrdDocumentsubtypeFilter"/>
-    				</LeftCondition>
-    				<RightCondition>
-<!--						REVISAR 
-						<Custom ref="dateExistsCondition"/>-->
-						<Custom ref="anonymousAccesAllow"/>
-    				</RightCondition>
-    			</And>
-    		</Definition>
-    	</Filter>
+
+        <Filter id="snrdFilter">
+            <Definition>
+                <And>
+                    <LeftCondition>
+                        <And>
+                            <LeftCondition>
+                                <And>
+                                    <LeftCondition>
+                                        <Custom ref="titleExistsCondition" />
+                                    </LeftCondition>
+                                    <RightCondition>
+                                        <Custom ref="creatorExistsCondition" />
+                                    </RightCondition>
+                                </And>
+                            </LeftCondition>
+                            <RightCondition>
+                                <Custom ref="dateExistsCondition" />
+                            </RightCondition>
+                        </And>
+                    </LeftCondition>
+                    <RightCondition>
+                        <And>
+                            <LeftCondition>
+                                <Custom ref="snrdDocumentsubtypeFilter" />
+                            </LeftCondition>
+                            <RightCondition>
+                                <Custom ref="anonymousAccesAllow" />
+                            </RightCondition>
+                        </And>
+                    </RightCondition>
+                </And>
+            </Definition>
+        </Filter>
     
     
         <!-- DRIVER filter for records returned by OAI-PMH.
@@ -470,7 +489,10 @@
         <CustomCondition id="creatorExistsCondition">
             <Class>org.dspace.xoai.filter.DSpaceMetadataExistsFilter</Class>
             <Configuration>
-                <string name="field">dcterms.creator.author</string>
+                <list name="fields">
+                    <string name="field">dcterms.creator.author</string>
+                    <string name="field">dcterms.creator.corporate</string>
+                </list>
             </Configuration>
         </CustomCondition>
         
@@ -482,11 +504,14 @@
             </Configuration>
         </CustomCondition>
         
-        <!-- This condition determines if an Item has a "dcterms.issued" -->
+        <!-- This condition determines if an Item has a "dcterms.issued" or a "dcterms.created -->
         <CustomCondition id="dateExistsCondition">
             <Class>org.dspace.xoai.filter.DSpaceMetadataExistsFilter</Class>
             <Configuration>
-                <string name="field">dcterms.issued</string>
+                <list name="fields">
+                    <string name="field">dcterms.issued</string>
+                    <string name="field">dcterms.created</string>
+                </list>
             </Configuration>
         </CustomCondition>
         


### PR DESCRIPTION
* Arreglo la posición en el mapeo de dc.identifier.uri y elimino el mapeo de dcterms.identifier.url
* Agrego al mapeo a dc.date el metadato dcterms.created, que se corresponde con los conjuntos de datos
* Agrego mas filtros para que items que no cumplan ciertas caracteristicas como que no tengan fecha o autores no sean mapeados
* Agrego a los editores y compilardores como dc.contributors en el mapeo y agrego a dc.creator.corporate como autores
* El tipo de acceso del recurso (si esta embargado, si es abierto o cerrado) ahora se mapea correctamente. Antes se mapeaba todo como openAccess ahora se dectecta si el item tiene algun bitstream embargado o si es restringido y se setea el valor correspondiente en el mapeo

Se debería aprobar el PR si el mapeo a snrd cumple con las directrices https://repositoriosdigitales.mincyt.gob.ar/files/Directrices_SNRD_2015.pdf