### PR TITLE
Fixes a mapeos al contexto snrd del OAI

### DIFF
--- a/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
@@ -149,7 +149,9 @@
 			</xsl:for-each>
 			<!-- dcterms.relation -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='relation']/doc:element/doc:field[@name='value']">
-				<dc:relation><xsl:value-of select="." /></dc:relation>
+				<xsl:if test="./text()">
+					<dc:relation><xsl:value-of select="." /></dc:relation>
+				</xsl:if>
 			</xsl:for-each>
 			<!-- dcterms.identifier.other -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='other']/doc:element/doc:field[@name='value']">

--- a/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
@@ -102,6 +102,10 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='cic']/doc:element[@name='thesis']/doc:element[@name='degree']/doc:element/doc:field[@name='value']">
 				<dc:description><xsl:value-of select="." /></dc:description>
 			</xsl:for-each>
+			<!-- dcterms.format dataset description -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='format']/doc:element/doc:field[@name='value']">
+				<dc:description><xsl:value-of select="." /></dc:description>
+			</xsl:for-each>
 			<!-- dcterms.issued -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='issued']/doc:element/doc:field[@name='value']">
 				<dc:date><xsl:value-of select="." /></dc:date>
@@ -121,10 +125,6 @@
             </xsl:for-each>
 			<!-- dcterms.extent -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='extent']/doc:element/doc:field[@name='value']">
-				<dc:format><xsl:value-of select="." /></dc:format>
-			</xsl:for-each>
-			<!-- dcterms.format -->
-			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='format']/doc:element/doc:field[@name='value']">
 				<dc:format><xsl:value-of select="." /></dc:format>
 			</xsl:for-each>
 			<!-- dcterms.medium -->

--- a/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
@@ -155,7 +155,9 @@
 			</xsl:for-each>
 			<!-- dcterms.identifier.other -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='other']/doc:element/doc:field[@name='value']">
-				<dc:relation><xsl:value-of select="." /></dc:relation>
+				<xsl:if test="./text()">
+					<dc:relation><xsl:value-of select="." /></dc:relation>
+				</xsl:if>
 			</xsl:for-each>
 			<!-- dc.rights -->
 			<!-- En el contexto snrd mostrar dc:rights dependiendo de si tiene o no embargo -->

--- a/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/cic_oai_dc.xsl
@@ -147,6 +147,10 @@
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='language']/doc:element/doc:field[@name='value']">
 				<dc:language><xsl:value-of select="." /></dc:language>
 			</xsl:for-each>
+			<!-- dcterms.relation -->
+			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='relation']/doc:element/doc:field[@name='value']">
+				<dc:relation><xsl:value-of select="." /></dc:relation>
+			</xsl:for-each>
 			<!-- dcterms.identifier.other -->
 			<xsl:for-each select="doc:metadata/doc:element[@name='dcterms']/doc:element[@name='identifier']/doc:element[@name='other']/doc:element/doc:field[@name='value']">
 				<dc:relation><xsl:value-of select="." /></dc:relation>

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -75,7 +75,7 @@
 	<xsl:template match="/doc:metadata/doc:element[@name='dc']/doc:element[@name='identifier']/doc:element[@name='uri']/doc:element/doc:field[@name='value']/text()">
 		<xsl:variable name="handle" select="/doc:metadata/doc:element[@name='others']/doc:field[@name='handle']"/>
 		<xsl:choose>
-			<xsl:when test="not(contains(.,'http://digital.cic.gba.gob.ar/'))">
+			<xsl:when test="not(contains(.,'https://digital.cic.gba.gob.ar/'))">
 				<xsl:value-of select="concat(.,$handle)"/>	
 			</xsl:when>
 			<xsl:otherwise>

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -146,6 +146,12 @@
 <!-- 		<xsl:text>info:eu-repo/semantics/openAccess</xsl:text> -->
 <!-- 	</xsl:template> -->
 
+	<!--  Removing dcterms.extent -->
+	<xsl:template match="/doc:metadata/doc:element[@name='dcterms']/doc:element[@name='extent']" />
+
+	<!--  Removing dcterms.medium -->
+	<xsl:template match="/doc:metadata/doc:element[@name='dcterms']/doc:element[@name='medium']" />
+
 	<!-- Formatting dcterms.relation -->
 	<xsl:template
 		match="/doc:metadata/doc:element[@name='dcterms']/doc:element[@name='relation']/doc:element/doc:field[@name='value']/text()">

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -101,11 +101,11 @@
 				<xsl:variable name="identificador" select="normalize-space(substring-after(.,':'))"/>
 				<xsl:value-of select="concat($prefix,$esquema,'/',$identificador)"/>
 			</xsl:when>
-			<xsl:otherwise>
+			<xsl:when test="contains(.,' ')">
 				<xsl:variable name="esquema" select="substring-before(.,' ')"/>
 				<xsl:variable name="identificador" select="normalize-space(substring-after(.,' '))"/>
 				<xsl:value-of select="concat($prefix,$esquema,'/',$identificador)"/>
-			</xsl:otherwise>
+			</xsl:when>
 		</xsl:choose>
 					
 	</xsl:template>

--- a/dspace/config/crosswalks/oai/transformers/snrd.xsl
+++ b/dspace/config/crosswalks/oai/transformers/snrd.xsl
@@ -146,6 +146,21 @@
 <!-- 		<xsl:text>info:eu-repo/semantics/openAccess</xsl:text> -->
 <!-- 	</xsl:template> -->
 
+	<!-- Formatting dcterms.relation -->
+	<xsl:template
+		match="/doc:metadata/doc:element[@name='dcterms']/doc:element[@name='relation']/doc:element/doc:field[@name='value']/text()">
+		<xsl:variable name="authority"
+			select="/doc:metadata/doc:element[@name='dcterms']/doc:element[@name='relation']/doc:element/doc:field[@name='authority']" />
+		<xsl:choose>
+			<xsl:when test="starts-with($authority, 'http')">
+				<xsl:value-of select="$authority" />
+			</xsl:when>
+			<xsl:when test="starts-with(., 'http')">
+				<xsl:value-of select="." />
+			</xsl:when>
+		</xsl:choose>
+	</xsl:template>
+
 	<!-- AUXILIARY TEMPLATES -->
 	
 	<xsl:template name="type-driver-version">

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -20,8 +20,6 @@
     		<Filter ref="snrdFilter"/>
     		<Set ref="snrdSet"/>
     		<Format ref="oaidc"/>
-    		<Format ref="xoai"/>
-    		
     		<Description>
     			This context complies with SNRD rules.
     		</Description>


### PR DESCRIPTION
Este PR agrupa correcciones de 5 tickets relacionados con errores en mapeos a OAI:

* [7109](http://trac.prebi.unlp.edu.ar/issues/7109) Se deshabilitó el prefix xoai del contexto snrd del oai
* [7132](http://trac.prebi.unlp.edu.ar/issues/7132) Corrección en el mapeo de dc.identifier.uri. Habia una regla en el transformer que hacía que si un identifier uri no venia con 'http://digital.cic.gba.gob.ar/' se le agregaba de nuevo el handle al final. Se cambió el "http" por "https" y salió andando.
* [7133](http://trac.prebi.unlp.edu.ar/issues/7133) Se corrigió el mapeo del metadato dcterms.relation. Ahora solo se mapea si el authority o el text_value tienen una URI válida, entonces se mapea esa uri poniendo como prioridad la del authority.
* [7154](http://trac.prebi.unlp.edu.ar/issues/7154) Se corrigió el de dcterms.identifier.other que a veces se mapeaba vacío. Había una regla que hacía que se mapee vacío cuando en el text_value no se indicada el tipo de identificador. Ahora si no viene con el tipo de identificador como prefijo separado con ":" o con " " no se mapea.
* [7144](http://trac.prebi.unlp.edu.ar/issues/7144) Se corrigió el mapeo al campo dc:format en oai para que solo mapee el mimetype. dcterms.extent, dcterms.medium y dcterms.format se estaban mapeando a dc.format además del mimetype. a dcterms.format se lo pasó para que mapee a dc:descrption, a los otros dos se los eliminó del mapeo.


