### PR TITLE
Revert "8261 Corrijo rotacion de los archivos de logs dspace.log y checker.log

### DIFF
--- a/dspace/config/log4j.properties
+++ b/dspace/config/log4j.properties
@@ -1,0 +1,112 @@
+###########################################################################
+# log4j.properties
+#
+# This is the primary log4j (logging) configuration file for DSpace. By default,
+# Log4j is configured to write log files that rotate daily. However, you may
+# tweak these settings based on your local needs / best practices.
+# For more information on log4j configuration, see:
+# https://logging.apache.org/log4j/1.2/manual.html
+###########################################################################
+
+# VARIABLES:
+# The following variables can be used to easily tweak the default log4j settings.
+# These variables are used by the log4j config / appenders later in this file.
+
+# log.dir
+#   Default log file directory for DSpace. Defaults to the 'log' subdirectory
+#   under [dspace.dir]. NOTE: The value of 'dspace.dir' will be replaced by
+#   its value in your configuration when DSpace is deployed (via Ant).
+log.dir=${dspace.dir}/log
+
+# loglevel.dspace
+#   Log level for all DSpace-specific code (org.dspace.*)
+#   Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
+#   Defaults to INFO
+loglevel.dspace=INFO
+
+# loglevel.other
+#   Log level for other third-party tools/APIs used by DSpace
+#   Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
+#   Defaults to INFO
+loglevel.other=INFO
+
+#La rotación de los archivos de logs será hecha externamente por LogRotator
+
+###########################################################################
+# A1 is the name of the appender for most DSpace activity.
+###########################################################################
+# The root category is the default setting for all non-DSpace code.
+# Change this from INFO to DEBUG to see extra logging created by non-DSpace
+# code.
+log4j.rootCategory=${loglevel.other}, A1
+# This line sets the logging level for DSpace code. Set this to DEBUG to see
+# extra detailed logging for DSpace code.
+log4j.logger.org.dspace=${loglevel.dspace}, A1
+# Do not change this line
+log4j.additivity.org.dspace=false
+
+log4j.appender.A1=org.apache.log4j.FileAppender
+log4j.appender.A1.File=${log.dir}/dspace.log
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d %-5p %c @ %m%n
+
+###########################################################################
+# A2 is the name of the appender for the Checksum Checker
+###########################################################################
+# This line sets the logging level for the checksum checker log file.
+# Set this to DEBUG to see extra detailed logging.
+log4j.logger.org.dspace.checker=INFO, A2
+# Do not change this line
+log4j.additivity.org.dspace.checker=false
+
+log4j.appender.A2=org.apache.log4j.FileAppender
+log4j.appender.A2.File=${log.dir}/checker.log
+log4j.appender.A2.layout=org.apache.log4j.PatternLayout
+log4j.appender.A2.layout.ConversionPattern=%d %-5p %c %x - %m%n
+
+###########################################################################
+# A3 is the name of the appender for Cocoon (XMLUI only)
+###########################################################################
+# These lines sets the logging level for the cocoon log file.
+# Set these to DEBUG to see extra detailed logging.
+log4j.logger.org.apache.cocoon=WARN, A3
+log4j.logger.org.apache.cocoon.caching.impl.CacheImpl=WARN, A3
+log4j.logger.org.apache.cocoon.i18n.XMLResourceBundle=WARN, A3
+log4j.logger.cocoon=WARN, A3
+log4j.logger.org.springframework=WARN, A3
+# Do not change these lines
+log4j.additivity.org.apache.cocoon=false
+log4j.additivity.cocoon=false
+log4j.additivity.org.springframework=false
+
+log4j.appender.A3=org.apache.log4j.FileAppender
+log4j.appender.A3.File=${log.dir}/cocoon.log
+log4j.appender.A3.layout=org.apache.log4j.PatternLayout
+log4j.appender.A3.layout.ConversionPattern=%d %-5p %c %x - %m%n
+
+###########################################################################
+# A4 is the name of the appender for Solr
+###########################################################################
+#log4j.logger.org.apache.solr=ERROR, A4
+#log4j.additivity.org.apache.solr=false
+#log4j.appender.A4=org.dspace.app.util.DailyFileAppender
+#log4j.appender.A4.File=${log.dir}/solr.log
+#log4j.appender.A4.DatePattern=yyyy-MM-dd
+#log4j.appender.A4.MaxLogs=4
+#log4j.appender.A4.layout=org.apache.log4j.PatternLayout
+#log4j.appender.A4.layout.ConversionPattern=%d %-5p %c %x - %m%n
+
+###########################################################################
+# Other settings
+###########################################################################
+
+# Block passwords from being exposed in Axis logs.
+# (DEBUG exposes passwords in Basic Auth)
+log4j.logger.org.apache.axis.handlers.http.HTTPAuthHandler=INFO
+
+# Block services logging except on exceptions
+log4j.logger.org.dspace.kernel=ERROR
+log4j.logger.org.dspace.services=ERROR
+log4j.logger.org.dspace.servicemanager=ERROR
+log4j.logger.org.dspace.providers=ERROR
+log4j.logger.org.dspace.utils=ERROR

--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -8,7 +8,7 @@
              NOTE: The value of 'dspace.dir' will be replaced by its value in
              your configuration when DSpace is installed. -->
         <Property name='log.dir'>${log4j:configParentLocation}/../log</Property>
-        <Property name='log.olddir'>/var/dspace/backups/old-logs</Property>
+
         <!-- Log level for all DSpace-specific code (org.dspace.*)
              Possible values (from most to least info):
 	     DEBUG, INFO, WARN, ERROR, FATAL -->
@@ -23,7 +23,7 @@
     <Appenders>
         <!-- A1 is for most DSpace activity -->
         <Appender name='A1'
-                  filePattern="${log.olddir}/dspace.log-%d{yyyy-MM-dd}.gz"
+                  filePattern="${log.dir}/dspace.log-%d{yyyy-MM-dd}"
                   type='RollingFile'
                   fileName='${log.dir}/dspace.log'
 
@@ -47,7 +47,7 @@
 
         <!-- A2 is for the checksum checker -->
         <Appender name='A2'
-                  filePattern="${log.olddir}/checker.log-%d{yyyy-MM-dd}.gz"
+                  filePattern="${log.dir}/checker.log-%d{yyyy-MM-dd}"
                   type='RollingFile'
                   fileName='${log.dir}/checker.log'>
             <Layout type='PatternLayout'

--- a/dspace/config/logrotate.conf
+++ b/dspace/config/logrotate.conf
@@ -1,0 +1,42 @@
+#DSpace LogRotate configuration. (copy to /etc/logrotate.d/dspace)
+
+/var/log/dspace/checker.log
+/var/log/dspace/cocoon.log
+/var/log/dspace/solr.log
+{
+  missingok
+  notifempty
+  weekly
+  size 100M
+  rotate 5
+  copytruncate
+  compress
+  delaycompress
+}
+
+/var/log/dspace/dspace.log {
+  copytruncate
+  daily
+  size 100M
+  rotate 9999999999999999
+  
+  dateext
+  dateformat .%Y-%m-%d
+  dateyesterday
+  compress
+  olddir old
+}
+
+#Tomcat8 LogRotate configuration (copy to /etc/logrotate.d/tomcat8)
+/var/log/tomcat8/*.log /var/log/tomcat8/*.txt /var/log/tomcat8/catalina.out{
+  missingok
+  notifempty
+  copytruncate
+  weekly
+  size 50M
+  rotate 5
+  compress
+  delaycompress
+  create 640 dspace adm
+}
+


### PR DESCRIPTION
Hago un revert del commit dc6c569bfcb4a9a154f89643b2a1645fe19e435d, porque se rotaban mal los logs. Lo que pasaba era que el log crecía demasiado y se llenaba el disco.

