### PR TITLE
Agrgeo regla para iniciar stack de docker en testing y fix de solr.server

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,7 @@ up:
 
 up-testing:
 	@echo "Starting up containers for $(COMPOSE_PROJECT_NAME)..."
-	docker-compose -f docker-compose.yml up
+	docker-compose -f docker-compose.yml up -d
 
 update:
 	@echo "Stopping containers for $(COMPOSE_PROJECT_NAME)..."

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,6 +8,10 @@ up:
 	@echo "Starting up containers for $(COMPOSE_PROJECT_NAME)..."
 	docker-compose -f docker-compose.yml -f others/docker-compose-debug.yml up -d
 
+up-testing:
+	@echo "Starting up containers for $(COMPOSE_PROJECT_NAME)..."
+	docker-compose -f docker-compose.yml up
+
 update:
 	@echo "Stopping containers for $(COMPOSE_PROJECT_NAME)..."
 	@docker-compose -f docker-compose.yml -f others/docker-compose-debug.yml stop

--- a/docker/rootfs/usr/local/sbin/dspace-manager.sh
+++ b/docker/rootfs/usr/local/sbin/dspace-manager.sh
@@ -45,6 +45,7 @@ init_config() {
 	set_dspace_property "db.username" "${POSTGRES_DB_USER}" $cfg_file
 	set_dspace_property "db.password" "${POSTGRES_DB_PASS}" $cfg_file
 	set_dspace_property "dspace.dir" "${DSPACE_DIR}" $cfg_file
+	set_dspace_property "solr.server" "http://dspacesolr:8983/solr" $cfg_file
 	
 	#this allows truncating the database
 	set_dspace_property "db.cleanDisabled" "false" $cfg_file


### PR DESCRIPTION
La idea es no mapear el puerto 8001 usado para debugging. También corrijo referencia a solr.server, ya que cuando se hace la ínstalación el local.cfg generado en install, tiene la propiedad solr.server apuntando a localhost y no al container de solr. Para eso uso el nombre del servicio "dspacesolr"