### PR TITLE
8700  Agregar facet por materia

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -2500,7 +2500,7 @@
         <property name="indexFieldName" value="subject"/>
         <property name="metadataFields">
             <list>
-                <value>dc.subject.materia</value>
+                <value>dcterms.subject.materia</value>
             </list>
         </property>
         <property name="facetLimit" value="5"/>


### PR DESCRIPTION
Para agregar el facet por materias no tuve que hacer mucho mas que cambiar un facet ya existente que estaba siendo usado en el los filtros pero estaba usando mal el metadato. Este facet estaba usando el metadato dc.subject.materia cuando tendria que ser dcterms.subject.materia.