### PR TITLE
ticket#10305-desactivo rotacion de log4j2.xml para activar logrotate

### DIFF
--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -23,18 +23,12 @@
     <Appenders>
         <!-- A1 is for most DSpace activity -->
         <Appender name='A1'
-                  filePattern="${log.dir}/dspace.log-%d{yyyy-MM-dd}"
-                  type='RollingFile'
-                  fileName='${log.dir}/dspace.log'
-
-        >
+                  type='File'
+                  fileName='${log.dir}/dspace.log'>
             <!-- NOTE: The %equals patterns are providing a default value of "unknown" if "correlationID" or
                  "requestID" are not currently set in the ThreadContext. -->
             <Layout type='PatternLayout'
                     pattern='%d %-5p %equals{%X{correlationID}}{}{unknown} %equals{%X{requestID}}{}{unknown} %c @ %m%n'/>
-            <policies>
-                <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
-            </policies>
             <!-- Sample deletion policy:  keep last 30 archived files
             <DefaultRolloverStrategy>
                 <Delete basePath='${log.dir}'>
@@ -47,14 +41,10 @@
 
         <!-- A2 is for the checksum checker -->
         <Appender name='A2'
-                  filePattern="${log.dir}/checker.log-%d{yyyy-MM-dd}"
-                  type='RollingFile'
+                  type='File'
                   fileName='${log.dir}/checker.log'>
             <Layout type='PatternLayout'
                     pattern='%m%n'/>
-            <policies>
-                <policy type='TimeBasedTriggeringPolicy'>yyyy-MM-dd</policy>
-            </policies>
             <!-- Sample deletion policy:  keep last 30 archived files
             <DefaultRolloverStrategy>
                 <Delete basePath='${log.dir}'>


### PR DESCRIPTION
## Referencias
#56 

## Descripción
Cambio los appenders de log4j2.xml de manera que la rotación de logs de dspace queda deshabilitada y se activa la rotación de logrotate
 
## Lista de cambios

1- Se cambia el tipo de los appenders de "RollingFile" a "File"
2- Se elimino la linea "filePattern" que indicaba cual era el formato de los rogs a rotar
3- Se eliminan las policies que indicaban  cual era el criterio de rotación de los logs 

